### PR TITLE
Refactor whole app into three main components

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -19,6 +19,7 @@
         "elm-lang/navigation": "2.0.1 <= v < 3.0.0",
         "elm-lang/websocket": "1.0.2 <= v < 2.0.0",
         "evancz/url-parser": "2.0.1 <= v < 3.0.0",
+        "jinjor/elm-contextmenu": "1.0.3 <= v < 2.0.0",
         "jinjor/elm-time-travel": "2.0.0 <= v < 3.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
         "rtfeldman/elm-css": "8.2.0 <= v < 9.0.0",

--- a/src/elm/Apps/Explorer/Context/Models.elm
+++ b/src/elm/Apps/Explorer/Context/Models.elm
@@ -1,0 +1,50 @@
+module Apps.Explorer.Context.Models exposing (..)
+
+import ContextMenu exposing (ContextMenu)
+import ContextMenu exposing (Overflow(..), Cursor(..), Direction(..), defaultConfig)
+import Color exposing (Color)
+
+
+type Context
+    = ContextNav
+    | ContextContent
+
+
+type alias ContextModel =
+    { menu : ContextMenu Context
+    , config : ContextMenu.Config
+    }
+
+
+winChrome : ContextMenu.Config
+winChrome =
+    { defaultConfig
+        | direction = RightBottom
+        , overflowX = Mirror
+        , overflowY = Mirror
+        , containerColor = white
+        , hoverColor = lightGray
+        , invertText = False
+        , cursor = Arrow
+        , rounded = False
+    }
+
+
+white : Color
+white =
+    Color.rgb 255 255 255
+
+
+lightGray : Color
+lightGray =
+    Color.rgb 238 238 238
+
+
+initialContext =
+    let
+        ( contextMenu, _ ) =
+            ContextMenu.init
+    in
+        { menu = contextMenu
+        , config = winChrome
+        }

--- a/src/elm/Apps/Explorer/Context/View.elm
+++ b/src/elm/Apps/Explorer/Context/View.elm
@@ -1,0 +1,47 @@
+module Apps.Explorer.Context.View
+    exposing
+        ( contextView
+        , contextNav
+        , contextContent
+        )
+
+import ContextMenu exposing (ContextMenu)
+import Apps.Explorer.Models exposing (Model)
+import Apps.Explorer.Messages exposing (Msg(ContextMenuMsg, Item))
+import Apps.Explorer.Context.Models exposing (Context(..))
+
+
+contextView model =
+    ContextMenu.view
+        model.context.config
+        ContextMenuMsg
+        (menu model)
+        model.context.menu
+
+
+menu : Model -> Context -> List (List ( ContextMenu.Item, Msg ))
+menu model context =
+    case context of
+        ContextNav ->
+            [ [ ( ContextMenu.item "A", Item 1 )
+              , ( ContextMenu.item "B", Item 2 )
+              ]
+            ]
+
+        ContextContent ->
+            [ [ ( ContextMenu.item "c", Item 3 )
+              , ( ContextMenu.item "d", Item 4 )
+              ]
+            ]
+
+
+contextNav =
+    contextFor ContextNav
+
+
+contextContent =
+    contextFor ContextContent
+
+
+contextFor context =
+    ContextMenu.open ContextMenuMsg context

--- a/src/elm/Apps/Explorer/Messages.elm
+++ b/src/elm/Apps/Explorer/Messages.elm
@@ -1,10 +1,14 @@
 module Apps.Explorer.Messages exposing (..)
 
+import ContextMenu exposing (ContextMenu)
 import Events.Models
 import Requests.Models
+import Apps.Explorer.Context.Models exposing (Context)
 
 
 type Msg
     = Event Events.Models.Event
     | Request Requests.Models.Request
     | Response Requests.Models.Request Requests.Models.Response
+    | ContextMenuMsg (ContextMenu.Msg Context)
+    | Item Int

--- a/src/elm/Apps/Explorer/Models.elm
+++ b/src/elm/Apps/Explorer/Models.elm
@@ -1,13 +1,18 @@
 module Apps.Explorer.Models exposing (..)
 
+import ContextMenu exposing (ContextMenu)
 import Game.Software.Models exposing (FilePath, rootPath)
+import Apps.Explorer.Context.Models exposing (Context, ContextModel, initialContext)
 
 
 type alias Model =
     { path : FilePath
+    , context : ContextModel
     }
 
 
 initialModel : Model
 initialModel =
-    { path = rootPath }
+    { path = rootPath
+    , context = initialContext
+    }

--- a/src/elm/Apps/Explorer/Subscriptions.elm
+++ b/src/elm/Apps/Explorer/Subscriptions.elm
@@ -1,0 +1,10 @@
+module Apps.Explorer.Subscriptions exposing (..)
+
+import ContextMenu exposing (ContextMenu)
+import Apps.Explorer.Models exposing (Model)
+import Apps.Explorer.Messages exposing (Msg(..))
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.map ContextMenuMsg (ContextMenu.subscriptions model.context.menu)

--- a/src/elm/Apps/Explorer/Update.elm
+++ b/src/elm/Apps/Explorer/Update.elm
@@ -1,12 +1,13 @@
 module Apps.Explorer.Update exposing (update)
 
+import ContextMenu exposing (ContextMenu)
+import Core.Messages exposing (CoreMsg)
 import Game.Models exposing (GameModel)
-import Game.Messages exposing (GameMsg)
 import Apps.Explorer.Models exposing (Model)
 import Apps.Explorer.Messages exposing (Msg(..))
 
 
-update : Msg -> Model -> GameModel -> ( Model, Cmd Msg, List GameMsg )
+update : Msg -> Model -> GameModel -> ( Model, Cmd Msg, List CoreMsg )
 update msg model game =
     case msg of
         Event event ->
@@ -16,4 +17,20 @@ update msg model game =
             ( model, Cmd.none, [] )
 
         Response request data ->
+            ( model, Cmd.none, [] )
+
+        ContextMenuMsg msg ->
+            let
+                ( contextMenu, cmd ) =
+                    ContextMenu.update msg model.context.menu
+
+                context =
+                    model.context
+
+                context_ =
+                    { context | menu = contextMenu }
+            in
+                ( { model | context = context_ }, Cmd.map ContextMenuMsg cmd, [] )
+
+        Item int ->
             ( model, Cmd.none, [] )

--- a/src/elm/Apps/Explorer/View.elm
+++ b/src/elm/Apps/Explorer/View.elm
@@ -7,6 +7,8 @@ import Html.CssHelpers
 import Game.Models exposing (GameModel)
 import Apps.Explorer.Messages exposing (Msg(..))
 import Apps.Explorer.Models exposing (Model)
+import Apps.Explorer.Context.Models exposing (Context(..))
+import Apps.Explorer.Context.View exposing (contextView, contextNav, contextContent)
 import Apps.Explorer.Style exposing (Classes(..))
 
 
@@ -19,14 +21,24 @@ view model game =
     div [ class [ Window ] ]
         [ viewExplorerColumn model game
         , viewExplorerMain model game
+        , contextView model
         ]
 
 
 viewExplorerColumn : Model -> GameModel -> Html Msg
 viewExplorerColumn model game =
-    div [ class [ Nav ] ] [ text "col" ]
+    div
+        [ contextNav
+        , class [ Nav ]
+        ]
+        [ text "col" ]
 
 
 viewExplorerMain : Model -> GameModel -> Html Msg
 viewExplorerMain model game =
-    div [ class [ Content ] ] [ text "main" ]
+    div
+        [ contextContent
+        , class
+            [ Content ]
+        ]
+        [ text "main" ]

--- a/src/elm/Apps/Landing/View.elm
+++ b/src/elm/Apps/Landing/View.elm
@@ -2,13 +2,13 @@ module Apps.Landing.View exposing (view)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Core.Models exposing (Model)
-import Core.Messages exposing (CoreMsg(MsgSignUp, MsgLogin))
+import Core.Models exposing (CoreModel)
+import Apps.Messages exposing (AppMsg(MsgSignUp, MsgLogin))
 import Apps.Login.View
 import Apps.SignUp.View
 
 
-view : Model -> Html CoreMsg
+view : CoreModel -> Html AppMsg
 view model =
     div [ id "view-landing" ]
         [ viewIntro
@@ -17,18 +17,18 @@ view model =
         ]
 
 
-viewIntro : Html CoreMsg
+viewIntro : Html AppMsg
 viewIntro =
     div [ id "view-intro" ]
         [ text "welcome to raquer ispirienci!"
         ]
 
 
-viewLogin : Model -> Html CoreMsg
+viewLogin : CoreModel -> Html AppMsg
 viewLogin model =
-    Html.map MsgLogin (Apps.Login.View.view model.appLogin model.game)
+    Html.map MsgLogin (Apps.Login.View.view model.apps.login model.game)
 
 
-viewSignUp : Model -> Html CoreMsg
+viewSignUp : CoreModel -> Html AppMsg
 viewSignUp model =
-    Html.map MsgSignUp (Apps.SignUp.View.view model.appSignUp model.game)
+    Html.map MsgSignUp (Apps.SignUp.View.view model.apps.signUp model.game)

--- a/src/elm/Apps/Login/Requests.elm
+++ b/src/elm/Apps/Login/Requests.elm
@@ -27,7 +27,8 @@ import Requests.Models
         )
 import Requests.Update exposing (queueRequest)
 import Requests.Decoder exposing (decodeRequest)
-import Game.Messages exposing (GameMsg, call)
+import Core.Messages exposing (CoreMsg)
+import Core.Dispatcher exposing (callAccount)
 import Game.Account.Messages exposing (AccountMsg(Login))
 import Game.Models exposing (GameModel)
 import Apps.Login.Messages exposing (Msg(Request))
@@ -38,7 +39,7 @@ type alias ResponseType =
     Response
     -> Model
     -> GameModel
-    -> ( Model, Cmd Msg, List GameMsg )
+    -> ( Model, Cmd Msg, List CoreMsg )
 
 
 
@@ -107,7 +108,8 @@ requestLoginHandler response model core =
         ResponseLogin (ResponseLoginOk data) ->
             let
                 loginCmd =
-                    call.account (Login (Just data.token))
+                    callAccount
+                        (Login (Just data.token))
             in
                 ( { model | loginFailed = False }, Cmd.none, [ loginCmd ] )
 

--- a/src/elm/Apps/Login/Update.elm
+++ b/src/elm/Apps/Login/Update.elm
@@ -1,7 +1,7 @@
 module Apps.Login.Update exposing (..)
 
+import Core.Messages exposing (CoreMsg)
 import Game.Models exposing (GameModel)
-import Game.Messages exposing (GameMsg)
 import Apps.Login.Models exposing (Model)
 import Apps.Login.Messages exposing (Msg(..))
 import Apps.Login.Requests
@@ -12,7 +12,7 @@ import Apps.Login.Requests
         )
 
 
-update : Msg -> Model -> GameModel -> ( Model, Cmd Msg, List GameMsg )
+update : Msg -> Model -> GameModel -> ( Model, Cmd Msg, List CoreMsg )
 update msg model core =
     case msg of
         SubmitLogin ->

--- a/src/elm/Apps/Messages.elm
+++ b/src/elm/Apps/Messages.elm
@@ -1,0 +1,22 @@
+module Apps.Messages exposing (AppMsg(..), appBinds)
+
+import Events.Models
+import Requests.Models
+import Core.Components exposing (Component)
+import Apps.Explorer.Messages
+import Apps.Login.Messages
+import Apps.SignUp.Messages
+
+
+type AppMsg
+    = MsgExplorer Apps.Explorer.Messages.Msg
+    | MsgLogin Apps.Login.Messages.Msg
+    | MsgSignUp Apps.SignUp.Messages.Msg
+    | Event Events.Models.Event
+    | Request Requests.Models.Request Component
+    | Response Requests.Models.Request Requests.Models.Response
+    | NoOp
+
+
+appBinds =
+    { login = Apps.Login.Messages.Response }

--- a/src/elm/Apps/Models.elm
+++ b/src/elm/Apps/Models.elm
@@ -1,0 +1,20 @@
+module Apps.Models exposing (AppModel, initialModel)
+
+import Apps.Explorer.Models
+import Apps.Login.Models
+import Apps.SignUp.Models
+
+
+type alias AppModel =
+    { login : Apps.Login.Models.Model
+    , signUp : Apps.SignUp.Models.Model
+    , explorer : Apps.Explorer.Models.Model
+    }
+
+
+initialModel : AppModel
+initialModel =
+    { login = Apps.Login.Models.initialModel
+    , signUp = Apps.SignUp.Models.initialModel
+    , explorer = Apps.Explorer.Models.initialModel
+    }

--- a/src/elm/Apps/SignUp/Context/Models.elm
+++ b/src/elm/Apps/SignUp/Context/Models.elm
@@ -1,0 +1,49 @@
+module Apps.SignUp.Context.Models exposing (..)
+
+import ContextMenu exposing (ContextMenu)
+import ContextMenu exposing (Overflow(..), Cursor(..), Direction(..), defaultConfig)
+import Color exposing (Color)
+
+
+type Context
+    = ContextOnly
+
+
+type alias ContextModel =
+    { menu : ContextMenu Context
+    , config : ContextMenu.Config
+    }
+
+
+winChrome : ContextMenu.Config
+winChrome =
+    { defaultConfig
+        | direction = RightBottom
+        , overflowX = Mirror
+        , overflowY = Mirror
+        , containerColor = white
+        , hoverColor = lightGray
+        , invertText = False
+        , cursor = Arrow
+        , rounded = False
+    }
+
+
+white : Color
+white =
+    Color.rgb 255 255 255
+
+
+lightGray : Color
+lightGray =
+    Color.rgb 238 238 238
+
+
+initialContext =
+    let
+        ( contextMenu, _ ) =
+            ContextMenu.init
+    in
+        { menu = contextMenu
+        , config = winChrome
+        }

--- a/src/elm/Apps/SignUp/Context/Subscriptions.elm
+++ b/src/elm/Apps/SignUp/Context/Subscriptions.elm
@@ -1,0 +1,10 @@
+module Apps.SignUp.Context.Subscriptions exposing (..)
+
+import ContextMenu exposing (ContextMenu)
+import Apps.SignUp.Models exposing (Model)
+import Apps.SignUp.Messages exposing (Msg(..))
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.map ContextMenuMsgS (ContextMenu.subscriptions model.context.menu)

--- a/src/elm/Apps/SignUp/Context/View.elm
+++ b/src/elm/Apps/SignUp/Context/View.elm
@@ -1,0 +1,36 @@
+module Apps.SignUp.Context.View
+    exposing
+        ( contextView
+        , contextOnly
+        )
+
+import ContextMenu exposing (ContextMenu)
+import Apps.SignUp.Models exposing (Model)
+import Apps.SignUp.Messages exposing (Msg(ContextMenuMsgS, ItemS))
+import Apps.SignUp.Context.Models exposing (Context(..))
+
+
+contextView model =
+    ContextMenu.view
+        model.context.config
+        ContextMenuMsgS
+        (menu model)
+        model.context.menu
+
+
+menu : Model -> Context -> List (List ( ContextMenu.Item, Msg ))
+menu model context =
+    case context of
+        ContextOnly ->
+            [ [ ( ContextMenu.item "A", ItemS 1 )
+              , ( ContextMenu.item "B", ItemS 2 )
+              ]
+            ]
+
+
+contextOnly =
+    contextFor ContextOnly
+
+
+contextFor context =
+    ContextMenu.open ContextMenuMsgS context

--- a/src/elm/Apps/SignUp/Messages.elm
+++ b/src/elm/Apps/SignUp/Messages.elm
@@ -1,7 +1,9 @@
 module Apps.SignUp.Messages exposing (Msg(..))
 
+import ContextMenu exposing (ContextMenu)
 import Events.Models
 import Requests.Models
+import Apps.SignUp.Context.Models exposing (Context)
 
 
 type Msg
@@ -15,3 +17,5 @@ type Msg
     | Event Events.Models.Event
     | Request Requests.Models.Request
     | Response Requests.Models.Request Requests.Models.Response
+    | ContextMenuMsgS (ContextMenu.Msg Context)
+    | ItemS Int

--- a/src/elm/Apps/SignUp/Models.elm
+++ b/src/elm/Apps/SignUp/Models.elm
@@ -1,5 +1,7 @@
 module Apps.SignUp.Models exposing (..)
 
+import Apps.SignUp.Context.Models exposing (ContextModel, initialContext)
+
 
 type alias FormError =
     { usernameErrors : String
@@ -14,6 +16,7 @@ type alias Model =
     , password : String
     , email : String
     , usernameTaken : Bool
+    , context : ContextModel
     }
 
 
@@ -32,4 +35,5 @@ initialModel =
     , password = ""
     , email = ""
     , usernameTaken = False
+    , context = initialContext
     }

--- a/src/elm/Apps/SignUp/Requests.elm
+++ b/src/elm/Apps/SignUp/Requests.elm
@@ -27,7 +27,7 @@ import Requests.Update exposing (queueRequest)
 import Requests.Decoder exposing (decodeRequest)
 import Json.Decode exposing (Decoder, string, decodeString, dict)
 import Json.Decode.Pipeline exposing (decode, required, optional)
-import Game.Messages exposing (GameMsg)
+import Core.Messages exposing (CoreMsg)
 import Game.Models exposing (GameModel)
 import Apps.SignUp.Messages exposing (Msg(Request))
 import Apps.SignUp.Models exposing (Model)
@@ -37,7 +37,7 @@ type alias ResponseType =
     Response
     -> Model
     -> GameModel
-    -> ( Model, Cmd Msg, List GameMsg )
+    -> ( Model, Cmd Msg, List CoreMsg )
 
 
 

--- a/src/elm/Apps/SignUp/Update.elm
+++ b/src/elm/Apps/SignUp/Update.elm
@@ -1,6 +1,7 @@
 module Apps.SignUp.Update exposing (..)
 
-import Game.Messages exposing (GameMsg)
+import ContextMenu exposing (ContextMenu)
+import Core.Messages exposing (CoreMsg)
 import Game.Models exposing (GameModel)
 import Apps.SignUp.Models exposing (Model, FormError)
 import Apps.SignUp.Messages exposing (Msg(..))
@@ -12,7 +13,7 @@ import Apps.SignUp.Requests
         )
 
 
-update : Msg -> Model -> GameModel -> ( Model, Cmd Msg, List GameMsg )
+update : Msg -> Model -> GameModel -> ( Model, Cmd Msg, List CoreMsg )
 update msg model core =
     case msg of
         SubmitForm ->
@@ -83,6 +84,22 @@ update msg model core =
 
         Response request data ->
             responseHandler request data model core
+
+        ContextMenuMsgS msg ->
+            let
+                ( contextMenu, cmd ) =
+                    ContextMenu.update msg model.context.menu
+
+                context =
+                    model.context
+
+                context_ =
+                    { context | menu = contextMenu }
+            in
+                ( { model | context = context_ }, Cmd.map ContextMenuMsgS cmd, [] )
+
+        ItemS int ->
+            ( model, Cmd.none, [] )
 
 
 getErrorsUsername : Model -> String

--- a/src/elm/Apps/SignUp/View.elm
+++ b/src/elm/Apps/SignUp/View.elm
@@ -6,46 +6,52 @@ import Html.Events exposing (onClick, onInput, onBlur)
 import Game.Models exposing (GameModel)
 import Apps.SignUp.Messages exposing (Msg(..))
 import Apps.SignUp.Models exposing (Model)
+import Apps.SignUp.Context.Models exposing (Context(..))
+import Apps.SignUp.Context.View exposing (contextView, contextOnly)
 
 
 view : Model -> GameModel -> Html Msg
 view model core =
-    Html.form
-        [ id "signup-form"
-        , action "javascript:void(0);"
-        ]
-        [ h1 [] [ text "Sign up" ]
-        , label [ for "email-field" ] [ text "email: " ]
-        , input
-            [ id "email-field"
-            , type_ "text"
-            , value model.email
-            , onInput (\str -> SetEmail str)
-            , onBlur ValidateEmail
+    div [ contextOnly ]
+        [ Html.form
+            [ id "signup-form"
+            , action "javascript:void(0);"
             ]
-            []
-        , div [ class "validation-error" ] [ text (viewErrorsEmail model) ]
-        , label [ for "username-field" ] [ text "username: " ]
-        , input
-            [ id "username-field"
-            , type_ "text"
-            , value model.username
-            , onInput (\str -> SetUsername str)
-            , onBlur ValidateUsername
+            [ h1 [] [ text "Sign up" ]
+            , label [ for "email-field" ] [ text "email: " ]
+            , input
+                [ id "email-field"
+                , type_ "text"
+                , value model.email
+                , onInput (\str -> SetEmail str)
+                , onBlur ValidateEmail
+                ]
+                []
+            , div [ class "validation-error" ] [ text (viewErrorsEmail model) ]
+            , label [ for "username-field" ] [ text "username: " ]
+            , input
+                [ id "username-field"
+                , type_ "text"
+                , value model.username
+                , onInput (\str -> SetUsername str)
+                , onBlur ValidateUsername
+                ]
+                []
+            , div [ class "validation-error" ] [ text (viewErrorsUsername model) ]
+            , label [ for "password-field" ] [ text "password: " ]
+            , input
+                [ id "password-field"
+                , type_ "password"
+                , value model.password
+                , onInput (\str -> SetPassword str)
+                , onBlur ValidatePassword
+                ]
+                []
+            , div [ class "validation-error" ] [ text (viewErrorsPassword model) ]
+            , button [ class ("signup-button " ++ signUpButtonClass model), onClick SubmitForm ] [ text "Sign up" ]
             ]
-            []
-        , div [ class "validation-error" ] [ text (viewErrorsUsername model) ]
-        , label [ for "password-field" ] [ text "password: " ]
-        , input
-            [ id "password-field"
-            , type_ "password"
-            , value model.password
-            , onInput (\str -> SetPassword str)
-            , onBlur ValidatePassword
-            ]
-            []
-        , div [ class "validation-error" ] [ text (viewErrorsPassword model) ]
-        , button [ class ("signup-button " ++ signUpButtonClass model), onClick SubmitForm ] [ text "Sign up" ]
+        , text "oi"
+        , contextView model
         ]
 
 

--- a/src/elm/Apps/Subscriptions.elm
+++ b/src/elm/Apps/Subscriptions.elm
@@ -1,0 +1,11 @@
+module Apps.Subscriptions exposing (subscriptions)
+
+import Apps.Models exposing (AppModel)
+import Apps.Messages exposing (AppMsg(..))
+import Apps.Explorer.Subscriptions
+import Apps.SignUp.Context.Subscriptions
+
+
+subscriptions : AppModel -> Sub AppMsg
+subscriptions model =
+    Sub.none

--- a/src/elm/Apps/Update.elm
+++ b/src/elm/Apps/Update.elm
@@ -1,0 +1,65 @@
+module Apps.Update exposing (..)
+
+import Requests.Models exposing (Request(NewRequest), NewRequestData)
+import Core.Messages exposing (CoreMsg(MsgApp))
+import Core.Components exposing (Component(..))
+import Core.Models exposing (CoreModel)
+import Apps.Models exposing (AppModel)
+import Apps.Messages exposing (AppMsg(..))
+import Apps.Explorer.Messages
+import Apps.Explorer.Update
+import Apps.SignUp.Messages
+import Apps.SignUp.Update
+import Apps.Login.Messages
+import Apps.Login.Update
+
+
+delegateRequest : NewRequestData -> Component -> List CoreMsg
+delegateRequest requestData component =
+    [ MsgApp (Request (NewRequest requestData) component) ]
+
+
+update : AppMsg -> AppModel -> CoreModel -> ( AppModel, Cmd AppMsg, List CoreMsg )
+update msg model core =
+    case msg of
+        MsgExplorer (Apps.Explorer.Messages.Request (NewRequest requestData)) ->
+            ( model, Cmd.none, delegateRequest requestData ComponentExplorer )
+
+        MsgExplorer subMsg ->
+            let
+                ( explorer_, cmd, coreMsg ) =
+                    Apps.Explorer.Update.update subMsg model.explorer core.game
+            in
+                ( { model | explorer = explorer_ }, Cmd.map MsgExplorer cmd, coreMsg )
+
+        MsgLogin (Apps.Login.Messages.Request (NewRequest requestData)) ->
+            ( model, Cmd.none, delegateRequest requestData ComponentLogin )
+
+        MsgLogin subMsg ->
+            let
+                ( login_, cmd, coreMsg ) =
+                    Apps.Login.Update.update subMsg model.login core.game
+            in
+                ( { model | login = login_ }, Cmd.map MsgLogin cmd, coreMsg )
+
+        MsgSignUp (Apps.SignUp.Messages.Request (NewRequest requestData)) ->
+            ( model, Cmd.none, delegateRequest requestData ComponentSignUp )
+
+        MsgSignUp subMsg ->
+            let
+                ( signUp_, cmd, coreMsg ) =
+                    Apps.SignUp.Update.update subMsg model.signUp core.game
+            in
+                ( { model | signUp = signUp_ }, Cmd.map MsgSignUp cmd, coreMsg )
+
+        Event _ ->
+            ( model, Cmd.none, [] )
+
+        Request _ _ ->
+            ( model, Cmd.none, [] )
+
+        Response _ _ ->
+            ( model, Cmd.none, [] )
+
+        NoOp ->
+            ( model, Cmd.none, [] )

--- a/src/elm/Core/Components.elm
+++ b/src/elm/Core/Components.elm
@@ -4,6 +4,7 @@ module Core.Components exposing (Component(..))
 type Component
     = ComponentGame
     | ComponentOS
+    | ComponentApp
     | ComponentExplorer
     | ComponentSignUp
     | ComponentLogin

--- a/src/elm/Core/Dispatcher.elm
+++ b/src/elm/Core/Dispatcher.elm
@@ -1,0 +1,104 @@
+module Core.Dispatcher
+    exposing
+        ( callAccount
+        , callSoftware
+        , callNetwork
+        , callServer
+        , callMeta
+        , callWM
+        , callDock
+        , callExplorer
+        , callSignUp
+        , callLogin
+        )
+
+import Core.Messages exposing (CoreMsg(MsgGame, MsgOS, MsgApp))
+import Game.Messages exposing (GameMsg(..))
+import OS.Messages exposing (OSMsg(..))
+import Apps.Messages exposing (AppMsg(..))
+import Game.Meta.Messages as Meta
+import Game.Account.Messages as Account
+import Game.Software.Messages as Software
+import Game.Network.Messages as Network
+import Game.Server.Messages as Server
+import OS.WindowManager.Messages as WM
+import OS.Dock.Messages as Dock
+import Apps.Explorer.Messages as Explorer
+import Apps.SignUp.Messages as SignUp
+import Apps.Login.Messages as Login
+
+
+-- Would love to do something like below, but I can't =(
+--
+-- callGame =
+--     { account = MsgGame (MsgAccount)
+--     , software = MsgGame (MsgSoftware)
+--     , network = MsgGame (MsgNetwork)
+--     , server = MsgGame (MsgServer)
+--     , meta = MsgGame (MsgMeta)
+--     }
+
+
+callGame : GameMsg -> CoreMsg
+callGame =
+    MsgGame
+
+
+callOS : OSMsg -> CoreMsg
+callOS =
+    MsgOS
+
+
+callApps : AppMsg -> CoreMsg
+callApps =
+    MsgApp
+
+
+callAccount : Account.AccountMsg -> CoreMsg
+callAccount msg =
+    callGame (MsgAccount msg)
+
+
+callSoftware : Software.SoftwareMsg -> CoreMsg
+callSoftware msg =
+    callGame (MsgSoftware msg)
+
+
+callNetwork : Network.NetworkMsg -> CoreMsg
+callNetwork msg =
+    callGame (MsgNetwork msg)
+
+
+callServer : Server.ServerMsg -> CoreMsg
+callServer msg =
+    callGame (MsgServer msg)
+
+
+callMeta : Meta.MetaMsg -> CoreMsg
+callMeta msg =
+    callGame (MsgMeta msg)
+
+
+callWM : WM.Msg -> CoreMsg
+callWM msg =
+    callOS (MsgWM msg)
+
+
+callDock : Dock.Msg -> CoreMsg
+callDock msg =
+    callOS (MsgDock msg)
+
+
+callExplorer : Explorer.Msg -> CoreMsg
+callExplorer msg =
+    callApps (MsgExplorer msg)
+
+
+callLogin : Login.Msg -> CoreMsg
+callLogin msg =
+    callApps (MsgLogin msg)
+
+
+callSignUp : SignUp.Msg -> CoreMsg
+callSignUp msg =
+    callApps (MsgSignUp msg)

--- a/src/elm/Core/Messages.elm
+++ b/src/elm/Core/Messages.elm
@@ -8,23 +8,19 @@ module Core.Messages
         , getRequestMsg
         )
 
-import Game.Messages
-import OS.Messages
-import Apps.Explorer.Messages
-import Apps.Login.Messages
-import Apps.SignUp.Messages
 import Navigation exposing (Location)
 import Events.Models exposing (Event)
 import Requests.Models exposing (Request, RequestStoreData, Response, ResponseDecoder)
 import Core.Components exposing (..)
+import Game.Messages exposing (GameMsg(..))
+import OS.Messages exposing (OSMsg(..))
+import Apps.Messages exposing (AppMsg(..), appBinds)
 
 
 type CoreMsg
     = MsgGame Game.Messages.GameMsg
     | MsgOS OS.Messages.OSMsg
-    | MsgExplorer Apps.Explorer.Messages.Msg
-    | MsgLogin Apps.Login.Messages.Msg
-    | MsgSignUp Apps.SignUp.Messages.Msg
+    | MsgApp Apps.Messages.AppMsg
     | OnLocationChange Location
     | DispatchEvent Event
     | DispatchResponse RequestStoreData ( String, Int )
@@ -45,9 +41,7 @@ type CoreMsg
 type alias EventBinds =
     { game : Event -> Game.Messages.GameMsg
     , os : Event -> OS.Messages.OSMsg
-    , explorer : Event -> Apps.Explorer.Messages.Msg
-    , login : Event -> Apps.Login.Messages.Msg
-    , signUp : Event -> Apps.SignUp.Messages.Msg
+    , apps : Event -> Apps.Messages.AppMsg
     }
 
 
@@ -55,9 +49,7 @@ eventBinds : EventBinds
 eventBinds =
     { game = Game.Messages.Event
     , os = OS.Messages.Event
-    , explorer = Apps.Explorer.Messages.Event
-    , login = Apps.Login.Messages.Event
-    , signUp = Apps.SignUp.Messages.Event
+    , apps = Apps.Messages.Event
     }
 
 
@@ -70,9 +62,7 @@ eventBinds =
 type alias RequestBinds =
     { game : Request -> Response -> Game.Messages.GameMsg
     , os : Request -> Response -> OS.Messages.OSMsg
-    , explorer : Request -> Response -> Apps.Explorer.Messages.Msg
-    , login : Request -> Response -> Apps.Login.Messages.Msg
-    , signUp : Request -> Response -> Apps.SignUp.Messages.Msg
+    , apps : Request -> Response -> Apps.Messages.AppMsg
     }
 
 
@@ -80,9 +70,7 @@ requestBinds : RequestBinds
 requestBinds =
     { game = Game.Messages.Response
     , os = OS.Messages.Response
-    , explorer = Apps.Explorer.Messages.Response
-    , login = Apps.Login.Messages.Response
-    , signUp = Apps.SignUp.Messages.Response
+    , apps = Apps.Messages.Response
     }
 
 
@@ -95,14 +83,17 @@ getRequestMsg component request response =
         ComponentOS ->
             MsgOS (requestBinds.os request response)
 
-        ComponentExplorer ->
-            MsgExplorer (requestBinds.explorer request response)
-
-        ComponentSignUp ->
-            MsgSignUp (requestBinds.signUp request response)
+        ComponentApp ->
+            MsgApp (requestBinds.apps request response)
 
         ComponentLogin ->
-            MsgLogin (requestBinds.login request response)
+            MsgApp
+                (MsgLogin
+                    (appBinds.login request response)
+                )
 
         ComponentInvalid ->
+            NoOp
+
+        _ ->
             NoOp

--- a/src/elm/Core/Models.elm
+++ b/src/elm/Core/Models.elm
@@ -1,6 +1,6 @@
 module Core.Models
     exposing
-        ( Model
+        ( CoreModel
         , Flags
         , initialModel
         )
@@ -9,19 +9,15 @@ import Requests.Models
 import Router.Router exposing (Route)
 import Game.Models
 import OS.Models
-import Apps.Explorer.Models
-import Apps.Login.Models
-import Apps.SignUp.Models
+import Apps.Models
 
 
-type alias Model =
-    { appLogin : Apps.Login.Models.Model
-    , appSignUp : Apps.SignUp.Models.Model
-    , appExplorer : Apps.Explorer.Models.Model
-    , route : Route
+type alias CoreModel =
+    { route : Route
     , requests : Requests.Models.Model
     , game : Game.Models.GameModel
     , os : OS.Models.Model
+    , apps : Apps.Models.AppModel
     }
 
 
@@ -30,13 +26,11 @@ type alias Flags =
     }
 
 
-initialModel : Router.Router.Route -> Int -> Model
+initialModel : Router.Router.Route -> Int -> CoreModel
 initialModel route seedInt =
-    { appLogin = Apps.Login.Models.initialModel
-    , appSignUp = Apps.SignUp.Models.initialModel
-    , appExplorer = Apps.Explorer.Models.initialModel
-    , route = route
+    { route = route
     , requests = Requests.Models.initialModel seedInt
     , game = Game.Models.initialModel
     , os = OS.Models.initialModel
+    , apps = Apps.Models.initialModel
     }

--- a/src/elm/Core/Subscriptions.elm
+++ b/src/elm/Core/Subscriptions.elm
@@ -1,14 +1,16 @@
 module Core.Subscriptions exposing (subscriptions)
 
 import WebSocket
-import Core.Messages exposing (CoreMsg(WSReceivedMessage, MsgOS))
-import Core.Models exposing (Model)
+import Core.Messages exposing (CoreMsg(WSReceivedMessage, MsgOS, MsgApp))
+import Core.Models exposing (CoreModel)
 import OS.WindowManager.Subscriptions
+import Apps.Subscriptions
 
 
-subscriptions : Model -> Sub CoreMsg
+subscriptions : CoreModel -> Sub CoreMsg
 subscriptions model =
     Sub.batch
         [ WebSocket.listen "ws://localhost:8080" WSReceivedMessage
         , Sub.map MsgOS (OS.WindowManager.Subscriptions.subscriptions model.os.wm)
+        , Sub.map MsgApp (Apps.Subscriptions.subscriptions model.apps)
         ]

--- a/src/elm/Core/View.elm
+++ b/src/elm/Core/View.elm
@@ -4,17 +4,17 @@ import Html exposing (Html, div, text)
 import Router.Router exposing (Route(..))
 import Game.Account.Models exposing (isAuthenticated)
 import Core.Messages exposing (CoreMsg(..))
-import Core.Models exposing (Model)
+import Core.Models exposing (CoreModel)
 import OS.View
 import Apps.Landing.View
 
 
-view : Model -> Html CoreMsg
+view : CoreModel -> Html CoreMsg
 view model =
     page model
 
 
-page : Model -> Html CoreMsg
+page : CoreModel -> Html CoreMsg
 page model =
     if isAuthenticated model.game.account then
         OS.View.view model
@@ -27,9 +27,9 @@ page model =
                 landingView model
 
 
-landingView : Model -> Html CoreMsg
+landingView : CoreModel -> Html CoreMsg
 landingView model =
-    Apps.Landing.View.view model
+    Html.map MsgApp (Apps.Landing.View.view model)
 
 
 notFoundView : Html msg

--- a/src/elm/Game/Messages.elm
+++ b/src/elm/Game/Messages.elm
@@ -1,8 +1,7 @@
-module Game.Messages exposing (GameMsg(..), call)
+module Game.Messages exposing (GameMsg(..))
 
 import Events.Models
 import Requests.Models
-import OS.Messages
 import Game.Account.Messages
 import Game.Server.Messages
 import Game.Network.Messages
@@ -19,14 +18,4 @@ type GameMsg
     | Event Events.Models.Event
     | Request Requests.Models.Request
     | Response Requests.Models.Request Requests.Models.Response
-    | ToOS OS.Messages.OSMsg
     | NoOp
-
-
-call =
-    { account = MsgAccount
-    , software = MsgSoftware
-    , network = MsgNetwork
-    , server = MsgServer
-    , meta = MsgMeta
-    }

--- a/src/elm/Game/Software/Update.elm
+++ b/src/elm/Game/Software/Update.elm
@@ -6,7 +6,11 @@ import Game.Software.Messages exposing (SoftwareMsg(..))
 import Game.Software.Models exposing (SoftwareModel)
 
 
-update : SoftwareMsg -> SoftwareModel -> GameModel -> ( SoftwareModel, Cmd GameMsg, List GameMsg )
+update :
+    SoftwareMsg
+    -> SoftwareModel
+    -> GameModel
+    -> ( SoftwareModel, Cmd GameMsg, List GameMsg )
 update msg model game =
     case msg of
         _ ->

--- a/src/elm/Game/Update.elm
+++ b/src/elm/Game/Update.elm
@@ -73,9 +73,6 @@ update msg model =
                 ( model_, cmd )
                     |> Update.andThen update (getGameMsg gameMsg)
 
-        ToOS _ ->
-            ( model, Cmd.none )
-
         NoOp ->
             ( model, Cmd.none )
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -5,12 +5,12 @@ import Navigation exposing (Location)
 import Router.Router exposing (parseLocation)
 import Core.Subscriptions exposing (subscriptions)
 import Core.Messages exposing (CoreMsg(OnLocationChange))
-import Core.Models exposing (Model, Flags, initialModel)
+import Core.Models exposing (CoreModel, Flags, initialModel)
 import Core.Update exposing (update)
 import Core.View exposing (view)
 
 
-init : Flags -> Location -> ( Model, Cmd CoreMsg )
+init : Flags -> Location -> ( CoreModel, Cmd CoreMsg )
 init flags location =
     let
         currentRoute =

--- a/src/elm/OS/Dock/Update.elm
+++ b/src/elm/OS/Dock/Update.elm
@@ -1,13 +1,13 @@
 module OS.Dock.Update exposing (update)
 
+import Core.Messages exposing (CoreMsg)
 import OS.Messages exposing (OSMsg)
-import Game.Messages exposing (GameMsg)
 import OS.Dock.Models exposing (Model)
 import OS.Dock.Messages exposing (Msg(..))
 
 
-update : Msg -> Model -> ( Model, Cmd OSMsg, List GameMsg, List OSMsg )
+update : Msg -> Model -> ( Model, Cmd OSMsg, List CoreMsg )
 update msg model =
     case msg of
         _ ->
-            ( model, Cmd.none, [], [] )
+            ( model, Cmd.none, [] )

--- a/src/elm/OS/Dock/View.elm
+++ b/src/elm/OS/Dock/View.elm
@@ -3,7 +3,7 @@ module OS.Dock.View exposing (view)
 import Html exposing (Html, div, text, button)
 import Html.Events exposing (onClick)
 import Core.Messages exposing (CoreMsg(..))
-import Core.Models exposing (Model)
+import Core.Models exposing (CoreModel)
 import OS.Messages exposing (OSMsg(..))
 import OS.WindowManager.Messages exposing (Msg(..))
 import OS.Dock.Models
@@ -13,12 +13,12 @@ import OS.Dock.Models
         )
 
 
-view : Model -> Html CoreMsg
+view : CoreModel -> Html CoreMsg
 view model =
     renderApplications model
 
 
-renderApplications : Model -> Html CoreMsg
+renderApplications : CoreModel -> Html CoreMsg
 renderApplications model =
     let
         applications =
@@ -30,7 +30,7 @@ renderApplications model =
         div [] html
 
 
-renderApplication : Model -> Application -> Html CoreMsg
+renderApplication : CoreModel -> Application -> Html CoreMsg
 renderApplication model application =
     div []
         [ button [ onClick (MsgOS (MsgWM (OpenWindow application.window))) ]

--- a/src/elm/OS/Messages.elm
+++ b/src/elm/OS/Messages.elm
@@ -1,9 +1,11 @@
-module OS.Messages exposing (OSMsg(..), call)
+module OS.Messages exposing (OSMsg(..))
 
 import Events.Models
 import Requests.Models
 import OS.WindowManager.Messages
+import OS.WindowManager.ContextHandler.Messages exposing (ContextMsg)
 import OS.Dock.Messages
+import Apps.Messages exposing (AppMsg)
 
 
 type OSMsg
@@ -12,10 +14,5 @@ type OSMsg
     | Event Events.Models.Event
     | Request Requests.Models.Request
     | Response Requests.Models.Request Requests.Models.Response
+    | ToApp AppMsg
     | NoOp
-
-
-call =
-    { wm = MsgWM
-    , dock = MsgDock
-    }

--- a/src/elm/OS/Update.elm
+++ b/src/elm/OS/Update.elm
@@ -1,6 +1,7 @@
 module OS.Update exposing (update)
 
 import Update.Extra as Update
+import Core.Messages exposing (CoreMsg)
 import OS.Messages exposing (OSMsg(..))
 import OS.Models exposing (Model)
 import Game.Messages exposing (GameMsg)
@@ -8,36 +9,40 @@ import OS.WindowManager.Update
 import OS.Dock.Update
 
 
-update : OSMsg -> Model -> ( Model, Cmd OSMsg )
+update : OSMsg -> Model -> ( Model, Cmd OSMsg, List CoreMsg )
 update msg model =
     case msg of
         MsgWM subMsg ->
             let
-                ( wm_, cmd, gameMsg, osMsg ) =
+                ( wm_, cmd, coreMsg ) =
                     OS.WindowManager.Update.update subMsg model.wm
             in
-                ( { model | wm = wm_ }, cmd )
-                    |> Update.andThen update (getOSMsg osMsg)
+                ( { model | wm = wm_ }, cmd, coreMsg )
 
+        -- |> Update.andThen update (getOSMsg osMsg) model toCore
         MsgDock subMsg ->
             let
-                ( dock_, cmd, gameMsg, osMsg ) =
+                ( dock_, cmd, coreMsg ) =
                     OS.Dock.Update.update subMsg model.dock
             in
-                ( { model | dock = dock_ }, cmd )
-                    |> Update.andThen update (getOSMsg osMsg)
+                ( { model | dock = dock_ }, cmd, coreMsg )
 
+        -- |> Update.andThen update (getOSMsg osMsg) toCore
         Event _ ->
-            ( model, Cmd.none )
+            ( model, Cmd.none, [] )
 
         Request _ ->
-            ( model, Cmd.none )
+            ( model, Cmd.none, [] )
 
         Response _ _ ->
-            ( model, Cmd.none )
+            ( model, Cmd.none, [] )
 
         NoOp ->
-            ( model, Cmd.none )
+            ( model, Cmd.none, [] )
+
+        -- handled by Core
+        ToApp _ ->
+            ( model, Cmd.none, [] )
 
 
 getOSMsg : List OSMsg -> OSMsg

--- a/src/elm/OS/View.elm
+++ b/src/elm/OS/View.elm
@@ -4,9 +4,9 @@ import Html exposing (..)
 import Html.Events exposing (onClick)
 import Html.CssHelpers
 import Router.Router exposing (Route(..))
-import Core.Models exposing (Model)
+import Core.Models exposing (CoreModel)
 import Core.Messages exposing (CoreMsg(..))
-import Game.Messages exposing (GameMsg(..), call)
+import Core.Dispatcher exposing (callAccount)
 import Game.Account.Messages exposing (AccountMsg(Logout))
 import OS.WindowManager.View
 import OS.Dock.View
@@ -16,7 +16,7 @@ import OS.Dock.View
     Html.CssHelpers.withNamespace "dreamwriter"
 
 
-view : Model -> Html CoreMsg
+view : CoreModel -> Html CoreMsg
 view model =
     case model.route of
         RouteNotFound ->
@@ -26,7 +26,7 @@ view model =
             viewDashboard model
 
 
-viewDashboard : Model -> Html CoreMsg
+viewDashboard : CoreModel -> Html CoreMsg
 viewDashboard model =
     div [ id "view-dashboard" ]
         [ viewHeader model
@@ -36,36 +36,34 @@ viewDashboard model =
         ]
 
 
-viewHeader : Model -> Html CoreMsg
+viewHeader : CoreModel -> Html CoreMsg
 viewHeader model =
-    Html.map MsgGame
-        (header []
-            [ div [ id "header-left" ]
-                []
-            , div [ id "header-mid" ]
-                []
-            , div [ id "header-right" ]
-                [ button [ onClick (call.account Logout) ]
-                    [ text "logout" ]
-                ]
+    header []
+        [ div [ id "header-left" ]
+            []
+        , div [ id "header-mid" ]
+            []
+        , div [ id "header-right" ]
+            [ button [ onClick (callAccount Logout) ]
+                [ text "logout" ]
             ]
-        )
+        ]
 
 
-viewSidebar : Model -> Html CoreMsg
+viewSidebar : CoreModel -> Html CoreMsg
 viewSidebar model =
     nav []
         [ text "nav" ]
 
 
-viewMain : Model -> Html CoreMsg
+viewMain : CoreModel -> Html CoreMsg
 viewMain model =
     main_ []
         [ OS.WindowManager.View.renderWindows model
         ]
 
 
-viewFooter : Model -> Html CoreMsg
+viewFooter : CoreModel -> Html CoreMsg
 viewFooter model =
     footer []
         [ OS.Dock.View.view model ]

--- a/src/elm/OS/WindowManager/ContextHandler/Messages.elm
+++ b/src/elm/OS/WindowManager/ContextHandler/Messages.elm
@@ -1,0 +1,10 @@
+module OS.WindowManager.ContextHandler.Messages exposing (..)
+
+import ContextMenu exposing (ContextMenu)
+import Apps.Explorer.Context.Models as Explorer
+import Apps.SignUp.Context.Models as SignUp
+
+
+type ContextMsg
+    = SignUpContext (ContextMenu.Msg SignUp.Context)
+    | ExplorerContext (ContextMenu.Msg Explorer.Context)

--- a/src/elm/OS/WindowManager/ContextHandler/Models.elm
+++ b/src/elm/OS/WindowManager/ContextHandler/Models.elm
@@ -1,0 +1,17 @@
+module OS.WindowManager.ContextHandler.Models exposing (..)
+
+import Apps.Explorer.Context.Models as Explorer
+import Apps.SignUp.Context.Models as SignUp
+
+
+type alias Model =
+    { explorer : Explorer.ContextModel
+    , signup : SignUp.ContextModel
+    }
+
+
+initialModel : Model
+initialModel =
+    { explorer = Explorer.initialContext
+    , signup = SignUp.initialContext
+    }

--- a/src/elm/OS/WindowManager/ContextHandler/Subscriptions.elm
+++ b/src/elm/OS/WindowManager/ContextHandler/Subscriptions.elm
@@ -1,0 +1,10 @@
+module OS.WindowManager.ContextHandler.Subscriptions exposing (subscriptions)
+
+import ContextMenu exposing (ContextMenu)
+import OS.WindowManager.Messages exposing (Msg(..))
+import OS.WindowManager.ContextHandler.Messages exposing (ContextMsg(..))
+
+
+subscriptions model =
+    Sub.map ContextHandlerMsg
+        (Sub.map ExplorerContext (ContextMenu.subscriptions model.explorer.menu))

--- a/src/elm/OS/WindowManager/ContextHandler/Update.elm
+++ b/src/elm/OS/WindowManager/ContextHandler/Update.elm
@@ -1,0 +1,23 @@
+module OS.WindowManager.ContextHandler.Update exposing (update)
+
+import Utils
+import Core.Messages exposing (CoreMsg)
+import OS.Messages exposing (OSMsg(..))
+import OS.WindowManager.ContextHandler.Messages exposing (ContextMsg(..))
+import OS.WindowManager.ContextHandler.Models exposing (Model)
+import OS.WindowManager.Windows exposing (GameWindow(..))
+import Apps.Messages
+
+
+update : ContextMsg -> Model -> ( Model, Cmd OSMsg, List CoreMsg )
+update msg model =
+    case msg of
+        ExplorerContext subMsg ->
+            let
+                cmd =
+                    Utils.msgToCmd (ToApp Apps.Messages.NoOp)
+            in
+                ( model, cmd, [] )
+
+        _ ->
+            ( model, Cmd.none, [] )

--- a/src/elm/OS/WindowManager/Messages.elm
+++ b/src/elm/OS/WindowManager/Messages.elm
@@ -3,6 +3,8 @@ module OS.WindowManager.Messages exposing (..)
 import Draggable
 import OS.WindowManager.Windows exposing (GameWindow)
 import OS.WindowManager.Models exposing (WindowID, Position)
+import OS.WindowManager.ContextHandler.Messages exposing (ContextMsg)
+import Apps.Explorer.Models
 
 
 type Msg
@@ -12,3 +14,4 @@ type Msg
     | StartDragging WindowID
     | StopDragging
     | DragMsg (Draggable.Msg WindowID)
+    | ContextHandlerMsg ContextMsg

--- a/src/elm/OS/WindowManager/Models.elm
+++ b/src/elm/OS/WindowManager/Models.elm
@@ -18,6 +18,7 @@ import Uuid
 import Random.Pcg exposing (Seed, step, initialSeed)
 import Draggable
 import OS.WindowManager.Windows exposing (GameWindow(..))
+import OS.WindowManager.ContextHandler.Models as ContextHandler
 
 
 type alias Model =
@@ -25,6 +26,7 @@ type alias Model =
     , seed : Seed
     , drag : Draggable.State WindowID
     , dragging : Maybe WindowID
+    , contextHandler : ContextHandler.Model
     }
 
 
@@ -84,6 +86,7 @@ initialModel =
     , seed = initialSeed 42
     , drag = Draggable.init
     , dragging = Nothing
+    , contextHandler = ContextHandler.initialModel
     }
 
 

--- a/src/elm/OS/WindowManager/Subscriptions.elm
+++ b/src/elm/OS/WindowManager/Subscriptions.elm
@@ -4,8 +4,12 @@ import Draggable
 import OS.Messages exposing (OSMsg(..))
 import OS.WindowManager.Messages exposing (Msg(..))
 import OS.WindowManager.Models exposing (Model)
+import OS.WindowManager.ContextHandler.Subscriptions as ContextHandler
 
 
 subscriptions : Model -> Sub OSMsg
 subscriptions model =
-    Sub.map MsgWM (Draggable.subscriptions DragMsg model.drag)
+    Sub.batch
+        [ Sub.map MsgWM (Draggable.subscriptions DragMsg model.drag)
+        , Sub.map MsgWM (ContextHandler.subscriptions model.contextHandler)
+        ]

--- a/src/elm/OS/WindowManager/Update.elm
+++ b/src/elm/OS/WindowManager/Update.elm
@@ -2,8 +2,8 @@ module OS.WindowManager.Update exposing (..)
 
 import Draggable
 import Draggable.Events exposing (onDragBy, onDragStart)
+import Core.Messages exposing (CoreMsg)
 import OS.Messages exposing (OSMsg(MsgWM))
-import Game.Messages exposing (GameMsg)
 import OS.WindowManager.Models
     exposing
         ( Model
@@ -13,9 +13,10 @@ import OS.WindowManager.Models
         , updateWindowPosition
         )
 import OS.WindowManager.Messages exposing (Msg(..))
+import OS.WindowManager.ContextHandler.Update as ContextHandler
 
 
-update : Msg -> Model -> ( Model, Cmd OSMsg, List GameMsg, List OSMsg )
+update : Msg -> Model -> ( Model, Cmd OSMsg, List CoreMsg )
 update msg model =
     case msg of
         OpenWindow window ->
@@ -26,14 +27,14 @@ update msg model =
                 model_ =
                     { model | windows = windows_, seed = seed_ }
             in
-                ( model_, Cmd.none, [], [] )
+                ( model_, Cmd.none, [] )
 
         CloseWindow id ->
             let
                 windows_ =
                     closeWindow model id
             in
-                ( { model | windows = windows_ }, Cmd.none, [], [] )
+                ( { model | windows = windows_ }, Cmd.none, [] )
 
         -- Drag
         OnDragBy delta ->
@@ -41,7 +42,7 @@ update msg model =
                 windows_ =
                     updateWindowPosition model delta
             in
-                ( { model | windows = windows_ }, Cmd.none, [], [] )
+                ( { model | windows = windows_ }, Cmd.none, [] )
 
         DragMsg dragMsg ->
             let
@@ -51,13 +52,20 @@ update msg model =
                 cmd_ =
                     Cmd.map MsgWM cmd
             in
-                ( model_, cmd_, [], [] )
+                ( model_, cmd_, [] )
 
         StartDragging id ->
-            ( { model | dragging = Just id }, Cmd.none, [], [] )
+            ( { model | dragging = Just id }, Cmd.none, [] )
 
         StopDragging ->
-            ( { model | dragging = Nothing }, Cmd.none, [], [] )
+            ( { model | dragging = Nothing }, Cmd.none, [] )
+
+        ContextHandlerMsg subMsg ->
+            let
+                ( contextHandler_, cmd, coreMsg ) =
+                    ContextHandler.update subMsg model.contextHandler
+            in
+                ( model, cmd, [] )
 
 
 dragConfig : Draggable.Config WindowID Msg

--- a/src/elm/OS/WindowManager/View.elm
+++ b/src/elm/OS/WindowManager/View.elm
@@ -7,7 +7,7 @@ import Html.CssHelpers
 import Css exposing (transform, translate2, asPairs, px, height, width)
 import Draggable
 import Core.Messages exposing (CoreMsg(..))
-import Core.Models exposing (Model)
+import Core.Models exposing (CoreModel)
 import OS.Messages exposing (OSMsg(..))
 import OS.WindowManager.Windows exposing (GameWindow(..))
 import OS.WindowManager.Models
@@ -19,8 +19,9 @@ import OS.WindowManager.Models
         )
 import OS.WindowManager.Messages exposing (Msg(..))
 import OS.WindowManager.Style as Css
+import Apps.Messages exposing (AppMsg(..))
 import Apps.Explorer.View
-import Apps.Login.View
+import Apps.SignUp.View
 
 
 { id, class, classList } =
@@ -32,28 +33,28 @@ styles =
     Css.asPairs >> style
 
 
-renderWindows : Model -> Html CoreMsg
+renderWindows : CoreModel -> Html CoreMsg
 renderWindows model =
     div [] (windowsFoldr (renderLoop model) [] (getOpenWindows model.os.wm))
 
 
-renderLoop : Model -> WindowID -> Window -> List (Html CoreMsg) -> List (Html CoreMsg)
+renderLoop : CoreModel -> WindowID -> Window -> List (Html CoreMsg) -> List (Html CoreMsg)
 renderLoop model id window acc =
     [ (renderWindow model window) ] ++ acc
 
 
-renderWindow : Model -> Window -> Html CoreMsg
+renderWindow : CoreModel -> Window -> Html CoreMsg
 renderWindow model window =
     case window.window of
         SignUpWindow ->
             windowWrapper
                 window
-                (Html.map MsgLogin (Apps.Login.View.view model.appLogin model.game))
+                (Html.map MsgApp (Html.map MsgSignUp (Apps.SignUp.View.view model.apps.signUp model.game)))
 
         ExplorerWindow ->
             windowWrapper
                 window
-                (Html.map MsgExplorer (Apps.Explorer.View.view model.appExplorer model.game))
+                (Html.map MsgApp (Html.map MsgExplorer (Apps.Explorer.View.view model.apps.explorer model.game)))
 
 
 windowWrapper : Window -> Html CoreMsg -> Html CoreMsg

--- a/src/elm/Requests/Models.elm
+++ b/src/elm/Requests/Models.elm
@@ -297,7 +297,13 @@ initialModel seedInt =
         }
 
 
-storeRequest : Model -> RequestID -> Component -> Request -> ResponseDecoder -> RequestStore
+storeRequest :
+    Model
+    -> RequestID
+    -> Component
+    -> Request
+    -> ResponseDecoder
+    -> RequestStore
 storeRequest model request_id component request response =
     Dict.insert request_id ( component, request, response ) model.requests
 

--- a/src/elm/Requests/Update.elm
+++ b/src/elm/Requests/Update.elm
@@ -26,7 +26,7 @@ import Requests.Models
 import WS.WS
 import Utils
 import Core.Components exposing (Component(ComponentInvalid))
-import Core.Models as Core
+import Core.Models exposing (CoreModel)
 
 
 {-| getRequestData will fetch the RequestStore and return the RequestStoreData
@@ -73,7 +73,7 @@ need to correctly route the response to the component (the 3-tuple
 which the server will sent with the response (on the key "request_id").
 
 -}
-makeRequest : Core.Model -> NewRequestData -> Component -> ( Core.Model, Cmd msg )
+makeRequest : CoreModel -> NewRequestData -> Component -> ( CoreModel, Cmd msg )
 makeRequest core requestData component =
     let
         model =


### PR DESCRIPTION
Now our already fractal app is even more fractal.

It has three main components: Game, OS and Apps

Game is responsible for communicating with the Helix server and storing the game data in a format the client (OS, Apps) can later query and interact with.

Apps are specific client windows, like the Web Browser or File Explorer or Log Viewer or Task Manager. They are contained within the OS, which is responsible for managing Windows (OS.WindowManager) as well as the Desktop background, Icon Dock, etc.

There's also now an easy way to send messages between these three components, implemented at `Core.Dispatcher`. 

Baked into this PR is an initial implementation (PoC) of Context Menus (right-click handling described at #17. My next PR will move this PoC into a scalable and well-organized architecture. It probably will have its own centralized component. This is required otherwise we'd have to add a custom subscriber on each Application / OS view that has custom context menus. 