### PR TITLE
Add Context (Local/Remote) for Apps

### DIFF
--- a/src/Apps/Context.elm
+++ b/src/Apps/Context.elm
@@ -1,0 +1,50 @@
+module Apps.Context exposing (..)
+
+
+type alias ContextApp instance =
+    { gateway : Maybe instance
+    , remote : Maybe instance
+    , context : ActiveContext
+    }
+
+
+type ActiveContext
+    = ContextGateway
+    | ContextEndpoint
+
+
+initialContext : instance -> ContextApp instance
+initialContext initialApp =
+    { gateway = Just initialApp
+    , remote = Nothing
+    , context = ContextGateway
+    }
+
+
+active : ContextApp instance -> ActiveContext
+active instance =
+    instance.context
+
+
+state : ContextApp instance -> Maybe instance
+state instance =
+    case (active instance) of
+        ContextGateway ->
+            instance.gateway
+
+        ContextEndpoint ->
+            instance.remote
+
+
+switch : ContextApp instance -> ContextApp instance
+switch instance =
+    let
+        context_ =
+            case (active instance) of
+                ContextGateway ->
+                    ContextEndpoint
+
+                ContextEndpoint ->
+                    ContextGateway
+    in
+        { instance | context = context_ }

--- a/src/Apps/Explorer/Context/View.elm
+++ b/src/Apps/Explorer/Context/View.elm
@@ -25,7 +25,7 @@ contextView model id =
     contextViewCreator
         ExplorerMsg.ContextMsg
         model
-        model.context
+        model.menu
         MenuMsg
         (menu id)
 

--- a/src/Apps/Explorer/Messages.elm
+++ b/src/Apps/Explorer/Messages.elm
@@ -9,7 +9,8 @@ import Apps.Explorer.Context.Messages as Context
 type Msg
     = OpenInstance InstanceID
     | CloseInstance InstanceID
+    | SwitchContext InstanceID
+    | ContextMsg Context.Msg
     | Event Events.Models.Event
     | Request Requests.Models.Request
     | Response Requests.Models.Request Requests.Models.Response
-    | ContextMsg Context.Msg

--- a/src/Apps/Explorer/Models.elm
+++ b/src/Apps/Explorer/Models.elm
@@ -2,8 +2,14 @@ module Apps.Explorer.Models exposing (..)
 
 import Dict
 import Game.Software.Models exposing (FilePath, rootPath)
-import Apps.Instances.Models exposing (Instances, initialState)
-import Apps.Explorer.Context.Models as Context
+import Apps.Instances.Models as Instance
+    exposing
+        ( Instances
+        , InstanceID
+        , initialState
+        )
+import Apps.Context as Context exposing (ContextApp)
+import Apps.Explorer.Context.Models as Menu
 
 
 type alias Explorer =
@@ -11,9 +17,13 @@ type alias Explorer =
     }
 
 
+type alias ContextExplorer =
+    ContextApp Explorer
+
+
 type alias Model =
-    { instances : Instances Explorer
-    , context : Context.Model
+    { instances : Instances ContextExplorer
+    , menu : Menu.Model
     }
 
 
@@ -26,5 +36,40 @@ initialExplorer =
 initialModel : Model
 initialModel =
     { instances = initialState
-    , context = Context.initialContext
+    , menu = Menu.initialContext
     }
+
+
+initialExplorerContext : ContextExplorer
+initialExplorerContext =
+    Context.initialContext initialExplorer
+
+
+getExplorerInstance : Instances ContextExplorer -> InstanceID -> ContextExplorer
+getExplorerInstance model id =
+    case (Instance.get model id) of
+        Just instance ->
+            instance
+
+        Nothing ->
+            initialExplorerContext
+
+
+getExplorerContext : ContextApp Explorer -> Explorer
+getExplorerContext instance =
+    case (Context.state instance) of
+        Just context ->
+            context
+
+        Nothing ->
+            initialExplorer
+
+
+getState : Model -> InstanceID -> Explorer
+getState model id =
+    getExplorerContext
+        (getExplorerInstance model.instances id)
+
+
+getCurrentPath explorer =
+    explorer.path

--- a/src/Apps/Explorer/Subscriptions.elm
+++ b/src/Apps/Explorer/Subscriptions.elm
@@ -7,4 +7,4 @@ import Apps.Explorer.Context.Subscriptions as Context
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Sub.map ContextMsg (Context.subscriptions model.context)
+    Sub.map ContextMsg (Context.subscriptions model.menu)

--- a/src/Apps/Explorer/View.elm
+++ b/src/Apps/Explorer/View.elm
@@ -5,9 +5,10 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Html.CssHelpers
 import Game.Models exposing (GameModel)
-import Apps.Instances.Models exposing (InstanceID)
+import Apps.Instances.Models as Instance exposing (InstanceID)
+import Apps.Context as Context
 import Apps.Explorer.Messages exposing (Msg(..))
-import Apps.Explorer.Models exposing (Model)
+import Apps.Explorer.Models exposing (..)
 import Apps.Explorer.Context.Models exposing (Context(..))
 import Apps.Explorer.Context.View exposing (contextView, contextNav, contextContent)
 import Apps.Explorer.Style exposing (Classes(..))
@@ -21,7 +22,7 @@ view : Model -> InstanceID -> GameModel -> Html Msg
 view model id game =
     div [ class [ Window ] ]
         [ viewExplorerColumn model game
-        , viewExplorerMain model game
+        , viewExplorerMain model id game
         , contextView model id
         ]
 
@@ -35,11 +36,23 @@ viewExplorerColumn model game =
         [ text "col" ]
 
 
-viewExplorerMain : Model -> GameModel -> Html Msg
-viewExplorerMain model game =
+viewExplorerMain : Model -> InstanceID -> GameModel -> Html Msg
+viewExplorerMain model id game =
     div
         [ contextContent
         , class
             [ Content ]
         ]
-        [ text (toString model) ]
+        [ renderMain model id ]
+
+
+renderMain model id =
+    let
+        explorer =
+            getState model id
+
+        path =
+            getCurrentPath explorer
+    in
+        div []
+            [ text path ]

--- a/src/Apps/Instances/Binds.elm
+++ b/src/Apps/Instances/Binds.elm
@@ -1,4 +1,4 @@
-module Apps.Instances.Binds exposing (open, close)
+module Apps.Instances.Binds exposing (open, close, context)
 
 import OS.WindowManager.Windows exposing (GameWindow(..))
 import Apps.Explorer.Messages as Explorer
@@ -14,3 +14,9 @@ close window msg =
     case window of
         ExplorerWindow ->
             Explorer.CloseInstance msg
+
+
+context window msg =
+    case window of
+        ExplorerWindow ->
+            Explorer.SwitchContext msg

--- a/src/Apps/Instances/Models.elm
+++ b/src/Apps/Instances/Models.elm
@@ -1,6 +1,8 @@
 module Apps.Instances.Models exposing (..)
 
 import Dict
+import Utils
+import OS.WindowManager.ContextHandler.Models as Menu
 import OS.WindowManager.Models exposing (WindowID)
 
 
@@ -47,16 +49,7 @@ close instances id =
 
 update : Instances app -> InstanceID -> app -> Instances app
 update instances id instance =
-    let
-        fnUpdate inst =
-            case inst of
-                Just _ ->
-                    Just instance
-
-                Nothing ->
-                    Nothing
-    in
-        Dict.update id fnUpdate instances
+    Utils.safeUpdateDict instances id instance
 
 
 initialState : Instances app

--- a/src/OS/WindowManager/Messages.elm
+++ b/src/OS/WindowManager/Messages.elm
@@ -15,3 +15,4 @@ type Msg
     | ToggleMaximize WindowID
     | MinimizeWindow WindowID
     | UpdateFocus (Maybe WindowID)
+    | SwitchContext WindowID

--- a/src/OS/WindowManager/View.elm
+++ b/src/OS/WindowManager/View.elm
@@ -18,6 +18,7 @@ import OS.WindowManager.Models
         , WindowID
         , getOpenWindows
         , windowsFoldr
+        , getContextText
         )
 import OS.WindowManager.Messages exposing (Msg(..))
 import OS.WindowManager.Style as Css
@@ -108,7 +109,16 @@ header window =
             , onMouseDown (UpdateFocus (Just window.id))
             ]
             [ headerTitle (windowTitle window) (windowIcon window)
+            , headerContext window.id window.context
             , headerButtons window.id
+            ]
+        ]
+
+
+headerContext id context =
+    div []
+        [ span [ onClick (SwitchContext id) ]
+            [ text (getContextText context)
             ]
         ]
 

--- a/src/OS/WindowManager/Windows.elm
+++ b/src/OS/WindowManager/Windows.elm
@@ -1,5 +1,10 @@
-module OS.WindowManager.Windows exposing (GameWindow(..))
+module OS.WindowManager.Windows exposing (GameWindow(..), WindowContext(..))
 
 
 type GameWindow
     = ExplorerWindow
+
+
+type WindowContext
+    = ContextGateway
+    | ContextEndpoint

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -4,8 +4,10 @@ module Utils
         , boolToString
         , maybeToString
         , delay
+        , safeUpdateDict
         )
 
+import Dict
 import Time
 import Task
 import Process
@@ -45,3 +47,21 @@ delay seconds msg =
     Process.sleep (Time.second * seconds)
         |> Task.andThen (always <| Task.succeed msg)
         |> Task.perform identity
+
+
+safeUpdateDict :
+    Dict.Dict comparable a
+    -> comparable
+    -> a
+    -> Dict.Dict comparable a
+safeUpdateDict dict key value =
+    let
+        fnUpdate item =
+            case item of
+                Just _ ->
+                    Just value
+
+                Nothing ->
+                    Nothing
+    in
+        Dict.update key fnUpdate dict


### PR DESCRIPTION
Context is yet another abstraction over Windows.

OS may have multiple applications. Each application may have multiple instances. Each instance may have multiple contexts. Each context must have one state (the application's).

Some (most) applications may behave differently depending on the context, i.e. if the application is running on the local server (Gateway) or on the remote server (Remote/Endpoint). 

For instance, imagine a file browser. If I'm browsing my own computer files, it will have one state (Gateway). If I'm browsing my target connection server, it will have different files (Remote/Endpoint).

For *each* instance, there must have only ONE active context. Either I'm viewing my files, or my remote's files.
Regardless of the active context, one instance may have stored, at the same time, the state for both Gateway and Remote. This is to allow a quick "switch" between contexts, without having to re-fetch everything from the server. 

Included on this PR is said "switch". It allows the player to quickly change the context of the instance (without the need to open a new one).

One important TODO is to rename the old Context (that referred to ContextMenu) to Menu. Now that we've added this Local/Remote context, it will get confusing. As such, all previous `Context` names will be renamed to Menu.