### PR TITLE
Add Gen.Log and add & enable Log tests

### DIFF
--- a/tests/Game/Servers/Logs/ModelTest.elm
+++ b/tests/Game/Servers/Logs/ModelTest.elm
@@ -1,0 +1,207 @@
+module Game.Servers.Logs.ModelTest exposing (all)
+
+import Expect
+import Test exposing (Test, describe)
+import Fuzz exposing (int, tuple)
+import TestUtils exposing (fuzz, once, ensureDifferentSeed)
+import Gen.Logs as Gen
+import Game.Servers.Logs.Models exposing (..)
+
+
+all : Test
+all =
+    describe "log"
+        [ logOperationsTests
+        ]
+
+
+logOperationsTests : Test
+logOperationsTests =
+    describe "log operations"
+        [ describe "add log"
+            addLogTests
+        , describe "update log"
+            updateLogTests
+        , describe "delete log"
+            deleteLogTests
+        ]
+
+
+
+--------------------------------------------------------------------------------
+-- Add Log
+--------------------------------------------------------------------------------
+
+
+addLogTests : List Test
+addLogTests =
+    [ describe "generic add log tests"
+        addLogGenericTests
+    ]
+
+
+addLogGenericTests : List Test
+addLogGenericTests =
+    [ fuzz (tuple ( int, int )) "can add a LogEntry but not a NoLog" <|
+        \seed ->
+            let
+                ( seed1, seed2 ) =
+                    ensureDifferentSeed seed
+
+                log =
+                    Gen.log seed1
+
+                model =
+                    addLog (Gen.model seed2) log
+
+                maybeLogExists =
+                    case getLogID log of
+                        Just id ->
+                            Just (logExists model id)
+
+                        Nothing ->
+                            Nothing
+
+                expectations =
+                    case log of
+                        LogEntry log ->
+                            Just True
+
+                        NoLog ->
+                            Nothing
+            in
+                Expect.equal expectations maybeLogExists
+    ]
+
+
+
+--------------------------------------------------------------------------------
+-- Update Log
+--------------------------------------------------------------------------------
+
+
+updateLogTests : List Test
+updateLogTests =
+    [ describe "generic update log tests"
+        updateLogGenericTests
+    ]
+
+
+updateLogGenericTests : List Test
+updateLogGenericTests =
+    [ fuzz (tuple ( int, int )) "update Log contents and noop on NoLog" <|
+        \seed ->
+            let
+                ( seed1, seed2 ) =
+                    ensureDifferentSeed seed
+
+                content =
+                    Gen.content seed2
+
+                log =
+                    Gen.log seed1
+
+                log_ =
+                    case log of
+                        LogEntry log ->
+                            LogEntry { log | content = content }
+
+                        NoLog ->
+                            NoLog
+
+                model =
+                    addLog (Gen.model seed2) log
+
+                model_ =
+                    updateLog model log_
+
+                maybeLogID =
+                    getLogID log
+
+                maybeLog =
+                    case maybeLogID of
+                        Just id ->
+                            getLogByID model_ id
+
+                        Nothing ->
+                            NoLog
+
+                maybeContent =
+                    getLogContent maybeLog
+
+                expectations =
+                    case log of
+                        LogEntry _ ->
+                            Just content
+
+                        NoLog ->
+                            Nothing
+            in
+                Expect.equal expectations maybeContent
+    ]
+
+
+
+--------------------------------------------------------------------------------
+-- Delete Log
+--------------------------------------------------------------------------------
+
+
+deleteLogTests : List Test
+deleteLogTests =
+    [ describe "generic delete log tests"
+        deleteLogGenericTests
+    ]
+
+
+deleteLogGenericTests : List Test
+deleteLogGenericTests =
+    [ fuzz (tuple ( int, int )) "log no longer exists" <|
+        \seed ->
+            let
+                ( seed1, seed2 ) =
+                    ensureDifferentSeed seed
+
+                log =
+                    Gen.log seed1
+
+                model =
+                    addLog (Gen.model seed2) log
+
+                model_ =
+                    removeLog model log
+
+                maybeLogExists =
+                    case getLogID log of
+                        Just id ->
+                            Just (logExists model_ id)
+
+                        Nothing ->
+                            Nothing
+
+                expectations =
+                    case log of
+                        LogEntry log ->
+                            Just False
+
+                        NoLog ->
+                            Nothing
+            in
+                Expect.equal expectations maybeLogExists
+    , fuzz (tuple ( int, int )) "can't delete a non-existing log" <|
+        \seed ->
+            let
+                ( seed1, seed2 ) =
+                    ensureDifferentSeed seed
+
+                log =
+                    Gen.log seed1
+
+                model =
+                    Gen.model seed2
+
+                model_ =
+                    removeLog model log
+            in
+                Expect.equal model model_
+    ]

--- a/tests/Gen/Logs.elm
+++ b/tests/Gen/Logs.elm
@@ -1,0 +1,120 @@
+module Gen.Logs exposing (..)
+
+import Arithmetic exposing (isEven)
+import Gen.Utils exposing (..)
+import Game.Servers.Logs.Models exposing (..)
+
+
+logID : Int -> LogID
+logID seedInt =
+    fuzz1 seedInt logIDSeed
+
+
+logIDSeed : StringSeed
+logIDSeed seed =
+    smallStringSeed seed
+
+
+content : Int -> String
+content seedInt =
+    fuzz1 seedInt contentSeed
+
+
+contentSeed : StringSeed
+contentSeed seed =
+    smallStringSeed seed
+
+
+stdLog : Int -> Log
+stdLog seedInt =
+    fuzz1 seedInt stdLogSeed
+
+
+stdLogSeed : Seed -> ( Log, Seed )
+stdLogSeed seed =
+    let
+        ( id, seed1 ) =
+            logIDSeed seed
+
+        ( content, seed2 ) =
+            contentSeed seed1
+    in
+        ( stdLogArgs id content, seed2 )
+
+
+stdLogArgs : LogID -> LogContent -> Log
+stdLogArgs id content =
+    LogEntry
+        { id = id
+        , content = content
+        }
+
+
+logsEmpty : Logs
+logsEmpty =
+    initialLogs
+
+
+model : Int -> Logs
+model seedInt =
+    logs seedInt
+
+
+log : Int -> Log
+log seedInt =
+    fuzz1 seedInt logSeed
+
+
+logSeed : Seed -> ( Log, Seed )
+logSeed seed =
+    let
+        ( result, seed_ ) =
+            intSeed seed
+    in
+        if isEven result then
+            stdLogSeed seed_
+        else
+            ( NoLog, seed_ )
+
+
+logList : Int -> List Log
+logList seedInt =
+    fuzz1 seedInt logListSeed
+
+
+logListSeed : Seed -> ( List Log, Seed )
+logListSeed seed =
+    let
+        ( size, seed_ ) =
+            intRangeSeed 1 100 seed
+
+        list =
+            List.range 1 size
+
+        reducer =
+            \_ ( logs, seed ) ->
+                let
+                    ( log, seed_ ) =
+                        logSeed seed
+                in
+                    ( log :: logs, seed_ )
+    in
+        List.foldl reducer ( [], seed_ ) list
+
+
+logs : Int -> Logs
+logs seedInt =
+    fuzz1 seedInt logsSeed
+
+
+logsSeed : Seed -> ( Logs, Seed )
+logsSeed seed =
+    let
+        ( logList, seed_ ) =
+            logListSeed seed
+
+        logs =
+            -- TODO: remove this lambda after moving logs to the last param
+            List.foldl (\log logs -> addLog logs log) logsEmpty logList
+    in
+        ( logs, seed_ )

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -5,6 +5,7 @@ import Expect
 import Fuzz exposing (list, int, tuple, string)
 import String
 import Game.Servers.Filesystem.ModelTest as FilesystemModel
+import Game.Servers.Logs.ModelTest as LogsModel
 import Game.Servers.Processes.ModelTest as ProcessesModel
 import Apps.Explorer.ModelTest as ExplorerModel
 
@@ -13,6 +14,7 @@ all : Test
 all =
     describe "heborn"
         [ FilesystemModel.all
+        , LogsModel.all
         , ProcessesModel.all
         , ExplorerModel.all
         , ExplorerModel.all


### PR DESCRIPTION
Note this is kinda a draft (~~but every of our current tests are kind of drafts~~ :joy: )

The PR adds:
- Log generator (Gen.Log)
- Log model tests
- enable log tests

As mentioned before, there are some quirks:
- "can add a LogEntry but not a NoLog" description sounds weird
- "update Log contents and noop on NoLog" test code is terribly ugly ('cause we can't pipe most log operations)
- some tests are using a "expectations" binding that makes sense, but doesn't seems very idiomatic

Should I connect this issue with #42?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/heborn/64)
<!-- Reviewable:end -->
