### PR TITLE
Fix fuzz1 type specification

### DIFF
--- a/tests/Gen/Utils.elm
+++ b/tests/Gen/Utils.elm
@@ -95,7 +95,7 @@ stringSeed min max seed =
         seed
 
 
-fuzz1 : Int -> (Seed -> ( String, a )) -> String
+fuzz1 : Int -> (Seed -> ( a, Seed )) -> a
 fuzz1 seedInt function =
     let
         seed0 =


### PR DESCRIPTION
Simple fix for a problem with fuzz1 type specification, now it's able to drop the seed for `(Any, Seed)` tuples :smile: