### PR TITLE
Filesystem review

### DIFF
--- a/src/Apps/Explorer/Models.elm
+++ b/src/Apps/Explorer/Models.elm
@@ -107,7 +107,7 @@ changePath explorer game path =
         explorer_ =
             case filesystem of
                 Just fs ->
-                    if pathExists fs path then
+                    if pathExists path fs then
                         setPath explorer path
                     else
                         explorer

--- a/tests/Game/Servers/Filesystem/ModelTest.elm
+++ b/tests/Game/Servers/Filesystem/ModelTest.elm
@@ -55,7 +55,7 @@ addFileGenericTests =
                     Gen.stdFile seed1
 
                 model =
-                    Gen.model seed1
+                    Gen.fsRandom seed1
 
                 model_ =
                     addFile stdFile model
@@ -73,7 +73,7 @@ addFileGenericTests =
                     Gen.stdFile seed1
 
                 model =
-                    Gen.model seed1
+                    Gen.fsRandom seed1
 
                 model_ =
                     addFileRecursively stdFile model
@@ -105,7 +105,7 @@ addFileGenericTests =
                     Gen.folder seed1
 
                 model =
-                    Gen.model seed2
+                    Gen.fsRandom seed2
 
                 model_ =
                     addFileRecursively folder model
@@ -121,7 +121,7 @@ addFileGenericTests =
                     setFilePath (Gen.path (seed1 + 1)) (Gen.folder seed1)
 
                 model =
-                    Gen.model seed1
+                    Gen.fsRandom seed1
 
                 path =
                     getFilePath folder
@@ -182,7 +182,7 @@ moveFileGenericTests =
                     Gen.path seed2
 
                 model1 =
-                    addFileRecursively stdFile (Gen.model seed1)
+                    addFileRecursively stdFile (Gen.fsRandom seed1)
 
                 model_ =
                     moveFile destination stdFile model1
@@ -209,7 +209,7 @@ moveStdFileTests =
                     getFilePath folder
 
                 model1 =
-                    addFileRecursively stdFile (Gen.model seed1)
+                    addFileRecursively stdFile (Gen.fsRandom seed1)
 
                 model2 =
                     addFileRecursively folder model1
@@ -252,7 +252,7 @@ moveStdFileTests =
                     getFilePath stdFile
 
                 model1 =
-                    addFileRecursively stdFile (Gen.model seed1)
+                    addFileRecursively stdFile (Gen.fsRandom seed1)
 
                 model2 =
                     addFileRecursively folder model1
@@ -287,7 +287,7 @@ moveStdFileTests =
                     getFilePath stdFile
 
                 model1 =
-                    addFileRecursively stdFile (Gen.model seed1)
+                    addFileRecursively stdFile (Gen.fsRandom seed1)
 
                 model2 =
                     addFileRecursively folder model1
@@ -317,7 +317,7 @@ moveFolderTests =
                     getFilePath destFolder
 
                 model1 =
-                    addFileRecursively originFolder (Gen.model seed1)
+                    addFileRecursively originFolder (Gen.fsRandom seed1)
 
                 model2 =
                     addFileRecursively destFolder model1
@@ -364,7 +364,7 @@ moveFolderTests =
                     getFilePath destFolder
 
                 model1 =
-                    addFileRecursively originFolder (Gen.model seed1)
+                    addFileRecursively originFolder (Gen.fsRandom seed1)
 
                 model2 =
                     addFileRecursively destFolder model1
@@ -399,7 +399,7 @@ moveFolderTests =
                     setFilePath newPath (Gen.stdFile (seed2 + 1))
 
                 model1 =
-                    addFileRecursively originFolder (Gen.model seed1)
+                    addFileRecursively originFolder (Gen.fsRandom seed1)
 
                 model2 =
                     addFileRecursively destFolder model1
@@ -446,7 +446,7 @@ moveFolderTests =
                     destination ++ pathSeparator ++ (getFileName originFolder)
 
                 model1 =
-                    addFileRecursively originFolder (Gen.model seed1)
+                    addFileRecursively originFolder (Gen.fsRandom seed1)
 
                 model2 =
                     addFileRecursively destFolder model1
@@ -482,7 +482,7 @@ deleteStdFileTests =
                     Gen.stdFile seed
 
                 model =
-                    addFileRecursively stdFile (Gen.model seed)
+                    addFileRecursively stdFile (Gen.fsRandom seed)
 
                 model_ =
                     removeFile stdFile model
@@ -505,7 +505,7 @@ deleteStdFileTests =
                     Gen.stdFile seed
 
                 model =
-                    addFileRecursively stdFile (Gen.model seed)
+                    addFileRecursively stdFile (Gen.fsRandom seed)
 
                 path =
                     getFilePath stdFile
@@ -533,7 +533,7 @@ deleteStdFileTests =
                     setFilePath path (Gen.file seed2)
 
                 model1 =
-                    addFileRecursively stdFile (Gen.model seed1)
+                    addFileRecursively stdFile (Gen.fsRandom seed1)
 
                 model2 =
                     addFileRecursively sister model1
@@ -576,7 +576,7 @@ deleteFolderTests =
                     setFilePath (getFilePath folder) file
 
                 model1 =
-                    addFileRecursively folder (Gen.model seed1)
+                    addFileRecursively folder (Gen.fsRandom seed1)
 
                 model2 =
                     addFileRecursively file_ model1
@@ -592,7 +592,7 @@ deleteFolderTests =
                     Gen.folder seed
 
                 model =
-                    addFileRecursively folder (Gen.model seed)
+                    addFileRecursively folder (Gen.fsRandom seed)
 
                 model_ =
                     removeFile folder model
@@ -615,7 +615,7 @@ deleteFolderTests =
                     Gen.folder seed
 
                 model =
-                    addFileRecursively folder (Gen.model seed)
+                    addFileRecursively folder (Gen.fsRandom seed)
 
                 path =
                     getFilePath folder

--- a/tests/Game/Servers/Filesystem/ModelTest.elm
+++ b/tests/Game/Servers/Filesystem/ModelTest.elm
@@ -58,7 +58,7 @@ addFileGenericTests =
                     Gen.model seed1
 
                 model_ =
-                    addFile model stdFile
+                    addFile stdFile model
             in
                 Expect.equal model model_
     , fuzz (tuple ( int, int ))
@@ -76,10 +76,10 @@ addFileGenericTests =
                     Gen.model seed1
 
                 model_ =
-                    addFileRecursively model stdFile
+                    addFileRecursively stdFile model
 
                 filesOnPath =
-                    getFilesOnPath model_ (getFilePath stdFile)
+                    getFilesOnPath (getFilePath stdFile) model_
 
                 maybeFile =
                     List.head
@@ -108,9 +108,9 @@ addFileGenericTests =
                     Gen.model seed2
 
                 model_ =
-                    addFileRecursively model folder
+                    addFileRecursively folder model
             in
-                Expect.equal (pathExists model_ (getFilePath folder)) True
+                Expect.equal (pathExists (getFilePath folder) model_) True
     , fuzz (tuple ( int, int )) "multiple files can exist on the same folder" <|
         \seed ->
             let
@@ -118,7 +118,7 @@ addFileGenericTests =
                     ensureDifferentSeed seed
 
                 folder =
-                    setFilePath (Gen.folder seed1) (Gen.path (seed1 + 1))
+                    setFilePath (Gen.path (seed1 + 1)) (Gen.folder seed1)
 
                 model =
                     Gen.model seed1
@@ -127,22 +127,22 @@ addFileGenericTests =
                     getFilePath folder
 
                 file1 =
-                    setFilePath (Gen.stdFile seed2) path
+                    setFilePath path (Gen.stdFile seed2)
 
                 file2 =
-                    setFilePath (Gen.stdFile (seed2 + 1)) path
+                    setFilePath path (Gen.stdFile (seed2 + 1))
 
                 model1 =
-                    addFile model folder
+                    addFile folder model
 
                 model2 =
-                    addFile model1 file1
+                    addFile file1 model1
 
                 model_ =
-                    addFile model2 file2
+                    addFile file2 model2
 
                 filesOnPath =
-                    getFilesOnPath model_ path
+                    getFilesOnPath path model_
             in
                 Expect.equal
                     ([ folder ] ++ [ file1 ] ++ [ file2 ])
@@ -182,10 +182,10 @@ moveFileGenericTests =
                     Gen.path seed2
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) stdFile
+                    addFileRecursively stdFile (Gen.model seed1)
 
                 model_ =
-                    moveFile model1 stdFile destination
+                    moveFile destination stdFile model1
             in
                 Expect.equal model_ model1
     ]
@@ -209,16 +209,16 @@ moveStdFileTests =
                     getFilePath folder
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) stdFile
+                    addFileRecursively stdFile (Gen.model seed1)
 
                 model2 =
-                    addFileRecursively model1 folder
+                    addFileRecursively folder model1
 
                 model_ =
-                    moveFile model2 stdFile destination
+                    moveFile destination stdFile model2
 
                 filesOnPath =
-                    getFilesOnPath model_ destination
+                    getFilesOnPath destination model_
 
                 maybeFile =
                     List.head
@@ -252,16 +252,16 @@ moveStdFileTests =
                     getFilePath stdFile
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) stdFile
+                    addFileRecursively stdFile (Gen.model seed1)
 
                 model2 =
-                    addFileRecursively model1 folder
+                    addFileRecursively folder model1
 
                 model_ =
-                    moveFile model2 stdFile (getFilePath folder)
+                    moveFile (getFilePath folder) stdFile model2
 
                 filesOnPath =
-                    getFilesOnPath model_ origin
+                    getFilesOnPath origin model_
 
                 maybeFile =
                     List.head
@@ -287,15 +287,15 @@ moveStdFileTests =
                     getFilePath stdFile
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) stdFile
+                    addFileRecursively stdFile (Gen.model seed1)
 
                 model2 =
-                    addFileRecursively model1 folder
+                    addFileRecursively folder model1
 
                 model_ =
-                    moveFile model2 stdFile (getFilePath folder)
+                    moveFile (getFilePath folder) stdFile model2
             in
-                Expect.equal (pathExists model_ origin) True
+                Expect.equal (pathExists origin model_) True
     ]
 
 
@@ -317,16 +317,16 @@ moveFolderTests =
                     getFilePath destFolder
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) originFolder
+                    addFileRecursively originFolder (Gen.model seed1)
 
                 model2 =
-                    addFileRecursively model1 destFolder
+                    addFileRecursively destFolder model1
 
                 model_ =
-                    moveFile model2 originFolder destination
+                    moveFile destination originFolder model2
 
                 filesOnPath =
-                    getFilesOnPath model_ destination
+                    getFilesOnPath destination model_
 
                 maybeFile =
                     List.head
@@ -364,18 +364,18 @@ moveFolderTests =
                     getFilePath destFolder
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) originFolder
+                    addFileRecursively originFolder (Gen.model seed1)
 
                 model2 =
-                    addFileRecursively model1 destFolder
+                    addFileRecursively destFolder model1
 
                 model_ =
-                    moveFile model2 originFolder destination
+                    moveFile destination originFolder model2
 
                 newPath =
                     destination ++ pathSeparator ++ (getFileName originFolder)
             in
-                Expect.equal (pathExists model_ newPath) True
+                Expect.equal (pathExists newPath model_) True
     , fuzz (tuple ( int, int )) "we can move a new file into the moved folder" <|
         \seed ->
             let
@@ -396,25 +396,25 @@ moveFolderTests =
 
                 -- todo: ensureDifferentSeed3
                 testFile =
-                    setFilePath (Gen.stdFile (seed2 + 1)) newPath
+                    setFilePath newPath (Gen.stdFile (seed2 + 1))
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) originFolder
+                    addFileRecursively originFolder (Gen.model seed1)
 
                 model2 =
-                    addFileRecursively model1 destFolder
+                    addFileRecursively destFolder model1
 
                 model3 =
-                    moveFile model2 originFolder destination
+                    moveFile destination originFolder model2
 
                 model4 =
-                    addFileRecursively model3 testFile
+                    addFileRecursively testFile model3
 
                 model_ =
-                    addFileRecursively model4 testFile
+                    addFileRecursively testFile model4
 
                 filesOnPath =
-                    getFilesOnPath model_ newPath
+                    getFilesOnPath newPath model_
 
                 maybeFile =
                     List.head
@@ -446,15 +446,15 @@ moveFolderTests =
                     destination ++ pathSeparator ++ (getFileName originFolder)
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) originFolder
+                    addFileRecursively originFolder (Gen.model seed1)
 
                 model2 =
-                    addFileRecursively model1 destFolder
+                    addFileRecursively destFolder model1
 
                 model_ =
-                    moveFile model2 originFolder destination
+                    moveFile destination originFolder model2
             in
-                Expect.equal (pathExists model_ origin) False
+                Expect.equal (pathExists origin model_) False
     ]
 
 
@@ -482,13 +482,13 @@ deleteStdFileTests =
                     Gen.stdFile seed
 
                 model =
-                    addFileRecursively (Gen.model seed) stdFile
+                    addFileRecursively stdFile (Gen.model seed)
 
                 model_ =
-                    removeFile model stdFile
+                    removeFile stdFile model
 
                 filesOnPath =
-                    getFilesOnPath model_ (getFilePath stdFile)
+                    getFilesOnPath (getFilePath stdFile) model_
 
                 maybeFile =
                     List.head
@@ -505,15 +505,15 @@ deleteStdFileTests =
                     Gen.stdFile seed
 
                 model =
-                    addFileRecursively (Gen.model seed) stdFile
+                    addFileRecursively stdFile (Gen.model seed)
 
                 path =
                     getFilePath stdFile
 
                 model_ =
-                    removeFile model stdFile
+                    removeFile stdFile model
             in
-                Expect.equal (pathExists model_ path) True
+                Expect.equal (pathExists path model_) True
     , fuzz
         (tuple ( int, int ))
         "'sister' files still exists on that path"
@@ -530,19 +530,19 @@ deleteStdFileTests =
                     getFilePath stdFile
 
                 sister =
-                    setFilePath (Gen.file seed2) path
+                    setFilePath path (Gen.file seed2)
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) stdFile
+                    addFileRecursively stdFile (Gen.model seed1)
 
                 model2 =
-                    addFileRecursively model1 sister
+                    addFileRecursively sister model1
 
                 model_ =
-                    removeFile model2 stdFile
+                    removeFile stdFile model2
 
                 filesOnPath =
-                    getFilesOnPath model_ path
+                    getFilesOnPath path model_
 
                 maybeFile =
                     List.head
@@ -573,16 +573,16 @@ deleteFolderTests =
                     Gen.file seed2
 
                 file_ =
-                    setFilePath file (getFilePath folder)
+                    setFilePath (getFilePath folder) file
 
                 model1 =
-                    addFileRecursively (Gen.model seed1) folder
+                    addFileRecursively folder (Gen.model seed1)
 
                 model2 =
-                    addFileRecursively model1 file_
+                    addFileRecursively file_ model1
 
                 model_ =
-                    removeFile model2 folder
+                    removeFile folder model2
             in
                 Expect.equal model2 model_
     , fuzz int "folder no longer exists on path" <|
@@ -592,13 +592,13 @@ deleteFolderTests =
                     Gen.folder seed
 
                 model =
-                    addFileRecursively (Gen.model seed) folder
+                    addFileRecursively folder (Gen.model seed)
 
                 model_ =
-                    removeFile model folder
+                    removeFile folder model
 
                 filesOnPath =
-                    getFilesOnPath model_ (getFilePath folder)
+                    getFilesOnPath (getFilePath folder) model_
 
                 maybeFile =
                     List.head
@@ -615,13 +615,13 @@ deleteFolderTests =
                     Gen.folder seed
 
                 model =
-                    addFileRecursively (Gen.model seed) folder
+                    addFileRecursively folder (Gen.model seed)
 
                 path =
                     getFilePath folder
 
                 model_ =
-                    removeFile model folder
+                    removeFile folder model
             in
-                Expect.equal (pathExists model_ path) False
+                Expect.equal (pathExists path model_) False
     ]

--- a/tests/Gen/Filesystem.elm
+++ b/tests/Gen/Filesystem.elm
@@ -206,7 +206,7 @@ fsRandom seedInt =
 
         model =
             List.foldr
-                (\file model_ -> Helper.addFileRecursively model_ file)
+                Helper.addFileRecursively
                 initialFilesystem
                 list
     in

--- a/tests/Gen/Utils.elm
+++ b/tests/Gen/Utils.elm
@@ -62,11 +62,7 @@ intSeed seed =
 
 
 int seedInt =
-    let
-        ( int, _ ) =
-            intSeed (Random.initialSeed seedInt)
-    in
-        int
+    fuzz1 seedInt intSeed
 
 
 intRangeSeed min max seed =
@@ -76,11 +72,7 @@ intRangeSeed min max seed =
 
 
 intRange min max seedInt =
-    let
-        ( int, _ ) =
-            intRangeSeed min max (Random.initialSeed seedInt)
-    in
-        int
+    fuzz1 seedInt (intRangeSeed min max)
 
 
 floatRange min max seedInt =

--- a/tests/Gen/Utils.elm
+++ b/tests/Gen/Utils.elm
@@ -55,6 +55,18 @@ listOfSeed size seed =
         ( list, seed2 )
 
 
+boolSeed : Seed -> ( Bool, Seed )
+boolSeed seed =
+    Random.step
+        Random.bool
+        seed
+
+
+bool : Int -> Bool
+bool seedInt =
+    fuzz1 seedInt boolSeed
+
+
 intSeed seed =
     Random.step
         (Random.Int.anyInt)

--- a/tests/Helper/Filesystem.elm
+++ b/tests/Helper/Filesystem.elm
@@ -10,7 +10,7 @@ addFolderReducer folderName ( filesystem, path ) =
             Folder { id = "id", name = folderName, path = path }
 
         filesystem_ =
-            addFile filesystem folder
+            addFile folder filesystem
 
         path_ =
             if path /= "/" then
@@ -23,7 +23,7 @@ addFolderReducer folderName ( filesystem, path ) =
 
 addPathParents : String -> Filesystem -> Filesystem
 addPathParents path filesystem =
-    if pathExists filesystem path then
+    if pathExists path filesystem then
         filesystem
     else
         let
@@ -43,9 +43,8 @@ allow us to have this assumption when adding files. It's usually safe to use
 addFileRecursively instead of addFile for tests, unless you want to test exactly
 the assumption that the path the file is being added to must exist.
 -}
-addFileRecursively : Filesystem -> File -> Filesystem
-addFileRecursively filesystem file =
-    -- TODO: remove flips once we move filesystem to last param
+addFileRecursively : File -> Filesystem -> Filesystem
+addFileRecursively file filesystem =
     filesystem
         |> addPathParents (getFilePath file)
-        |> (flip addFile) file
+        |> addFile file

--- a/tests/Helper/Filesystem.elm
+++ b/tests/Helper/Filesystem.elm
@@ -45,20 +45,7 @@ the assumption that the path the file is being added to must exist.
 -}
 addFileRecursively : Filesystem -> File -> Filesystem
 addFileRecursively filesystem file =
-    let
-        path =
-            getFilePath file
-
-        -- TODO: change this to use pipes once we move filesystem to last
-        -- param:
-        --
-        -- filesystem
-        --     |> addPathParents file.path
-        --     |> addFile file
-        filesystemWithParents =
-            addPathParents path filesystem
-
-        filesystemWithFile =
-            addFile filesystemWithParents file
-    in
-        filesystemWithFile
+    -- TODO: remove flips once we move filesystem to last param
+    filesystem
+        |> addPathParents (getFilePath file)
+        |> (flip addFile) file

--- a/tests/Helper/Filesystem.elm
+++ b/tests/Helper/Filesystem.elm
@@ -1,8 +1,15 @@
-module Helper.Filesystem exposing (addFileRecursively)
+module Helper.Filesystem
+    exposing
+        ( addFileRecursively
+        , addPathParents
+        )
 
 import Game.Servers.Filesystem.Models exposing (..)
 
 
+{-| Private function used by a reducer in addPathParents to add folder to given
+filesystem.
+-}
 addFolderReducer : String -> ( Filesystem, String ) -> ( Filesystem, String )
 addFolderReducer folderName ( filesystem, path ) =
     let
@@ -21,6 +28,8 @@ addFolderReducer folderName ( filesystem, path ) =
         ( filesystem_, path_ )
 
 
+{-| Like "mkdir -p", add folders recursively for given path.
+-}
 addPathParents : String -> Filesystem -> Filesystem
 addPathParents path filesystem =
     if pathExists path filesystem then

--- a/tests/Helper/Playstate.elm
+++ b/tests/Helper/Playstate.elm
@@ -45,10 +45,10 @@ one seed1 seed2 =
             Gen.Filesystem.folder (seed2 + 1)
 
         filesystem1 =
-            addFileRecursively (getFilesystemSafe server) file
+            addFileRecursively file (getFilesystemSafe server)
 
         filesystem_ =
-            addFileRecursively filesystem1 folder
+            addFileRecursively folder filesystem1
 
         server_ =
             updateFilesystem server filesystem_


### PR DESCRIPTION
Depends on: Nothing

---

I'm reviewing our Filesystem models and helpers.

#### TODO list

- [x] Update addFileRecursively to work recursively (done)
- [x] Review Filesystem model as a whole (done)
- [x] Review Filesystem tests (done, check notes)
- [x] Review Gen.Filesystem (done, check notes)
- [x] Refactor Filesystem tests (done)

Just a few things to clear and it's ready for full revision.

---

#### PROPOSALS list

- [x] Maybe making `addPathParents : String -> Filesystem -> Filesystem` public as it could be useful.
- [x] Add a comment separator for private functions (like the ones we use to split tests). (check notes)
- [x] Stop assuming list ordering (on tests) unless strictly needed (discussed personally)

---

#### REVIEW/FIXME annotations list

We have some fixmes for page content.


---

#### NOTES

- `addFileRecursively` splits a string by common slashes and rejects "empty string named folders", the filtering could be replaced with a tail select (the head is always an empty string with paths including the root slash).
- Tests are "okay", they need some refactor, but it's better to do it while moving the container (filesystem) param around. While checking, it got to my attention that the tests are generating file paths with repeated patterns, for example, it would generate paths with "/abc/abc/abc/abc/abc", I don't know if it's okay, but maybe I could change it to generate better paths.
- I found some problems with `Gen.Filesystem`, it's a little inconsistent and doesn't include a seed function for every generator. it might have something to do with the previous problem.
- Private functions aren't commonly documented on elm, lets just explain that it's private and what it does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/heborn/76)
<!-- Reviewable:end -->
