### PR TITLE
Gen.Log as Fuzzers and Generators 

### DIFF
--- a/tests/Gen/Utils.elm
+++ b/tests/Gen/Utils.elm
@@ -1,10 +1,11 @@
 module Gen.Utils exposing (..)
 
-import Random
-import Random.Int
-import Random.Float
-import Random.String
-import Random.Char
+import Shrink
+import Fuzz as Fuzz exposing (Fuzzer)
+import Random.Pcg as Random exposing (Generator)
+import Random.Pcg.Char as RandomChar
+import Random.Pcg.Int as RandomInt
+import Random.Pcg.String as RandomString
 
 
 type alias Seed =
@@ -70,7 +71,7 @@ bool seedInt =
 
 intSeed seed =
     Random.step
-        (Random.Int.anyInt)
+        (RandomInt.anyInt)
         seed
 
 
@@ -126,7 +127,7 @@ smallStringSeed seed =
 stringSeed : Int -> Int -> StringSeed
 stringSeed min max seed =
     Random.step
-        (Random.String.rangeLengthString min max Random.Char.english)
+        (RandomString.rangeLengthString min max RandomChar.english)
         seed
 
 

--- a/tests/Gen/Utils.elm
+++ b/tests/Gen/Utils.elm
@@ -1,11 +1,12 @@
 module Gen.Utils exposing (..)
 
-import Shrink
-import Fuzz as Fuzz exposing (Fuzzer)
+import Fuzz exposing (Fuzzer)
 import Random.Pcg as Random exposing (Generator)
 import Random.Pcg.Char as RandomChar
 import Random.Pcg.Int as RandomInt
+import Random.Pcg.Float as RandomFloat
 import Random.Pcg.String as RandomString
+import Shrink exposing (noShrink)
 
 
 type alias Seed =
@@ -14,6 +15,21 @@ type alias Seed =
 
 type alias StringSeed =
     Seed -> ( String, Seed )
+
+
+unique : Generator String
+unique =
+    RandomString.rangeLengthString 64 64 RandomChar.english
+
+
+stringRange : Int -> Int -> Generator String
+stringRange min max =
+    RandomString.rangeLengthString min max RandomChar.english
+
+
+fuzzer : Generator a -> Fuzzer a
+fuzzer f =
+    Fuzz.custom f Shrink.noShrink
 
 
 listOfInt : Int -> Int -> List Int
@@ -95,7 +111,7 @@ float seedInt =
 
 floatSeed seed =
     Random.step
-        Random.Float.anyFloat
+        RandomFloat.anyFloat
         seed
 
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -6,7 +6,7 @@
     "source-directories": [
         ".",
         "../src",
-	"../vendor/elm-phoenix/src"
+	    "../vendor/elm-phoenix/src"
     ],
     "exposed-modules": [],
     "dependencies": {
@@ -14,12 +14,13 @@
         "danyx23/elm-uuid": "2.0.2 <= v < 3.0.0",
         "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
-        "elm-community/random-extra": "2.0.0 <= v < 3.0.0",
+        "elm-community/shrink": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
         "evancz/url-parser": "2.0.1 <= v < 3.0.0",
         "jinjor/elm-contextmenu": "1.0.3 <= v < 2.0.0",
+        "kress95/random-pcg-extra": "1.0.1 <= v < 2.0.0",
         "lynn/elm-arithmetic": "2.0.3 <= v < 3.0.0",
         "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
         "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",


### PR DESCRIPTION
Depends on: Nothing

This is a pretty fun PR, because it reduces a lot the boilerplate we need to write. (for tests)

This proof-of-concept demonstrates how to replace our test scheme that manages seeds manually with a cleaner approach that composes _Generators_ and _Fuzzers_.

I strongly believe that this is the correct way to use `Random`, specially because it removes the seed management from our backs, consequently reducing a lot the cognitive load from our test code.

There are some drawbacks too, we have no control of our seeds, and we can't compose with `elm-core` `Random` without writing boilerplate or forking (like I did with [`random-pcg-extra`](kress95/random-pcg-extra) - and I believe this fork should be moved to the organization).

This also doesn't break our plans for `Playstate`, it actually makes its code cleaner as it also would not have to manage seeds.

--There's even more ways to reduce the boilerplate, wrapping (`fuzz`, `tuple`, `tuple3`, `tuple4`, `tuple5`) to convert generators to fuzzers would remove the need for any kind of fuzzer function on _Gens_, but it would add some startup overhead for each test we add (not much, I doubt we would perceive it), and we can't do it now as it would break other tests.-- Another drawback for that:

> I was going to make wrappers for `fuzz`, `tuple`, `tuple3`, `tuple4`, `tuple5` - to remove more
> boilerplate, but doing that would remove our ability to build fuzzers with shrinkers, so, unless
> we're not going to use shrinkers, it's better to keep that boilerplate there.

**EDIT:** This PR is not a proof of concept anymore, it's a proposed change.

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/heborn/86)
<!-- Reviewable:end -->
