### PR TITLE
Block changing bounces while connected to some endpoint

### DIFF
--- a/src/Core/Subscriptions.elm
+++ b/src/Core/Subscriptions.elm
@@ -56,7 +56,7 @@ play model =
 
 os : Game.Model -> OS.Model -> Sub Msg
 os game model =
-    case Game.fromActiveServer game of
+    case Game.fromGateway game of
         Just data ->
             model
                 |> OS.subscriptions data

--- a/src/Core/Update.elm
+++ b/src/Core/Update.elm
@@ -144,7 +144,7 @@ game msg model =
 
 os : OS.Msg -> PlayModel -> ( Model, Cmd Msg )
 os msg model =
-    case Game.fromActiveServer model.game of
+    case Game.fromGateway model.game of
         Just data ->
             let
                 ( os, cmd, dispatch ) =

--- a/src/Core/View.elm
+++ b/src/Core/View.elm
@@ -15,7 +15,7 @@ view model =
             Html.map LandingMsg (Landing.view model)
 
         Play model ->
-            case Game.fromActiveServer model.game of
+            case Game.fromGateway model.game of
                 Just data ->
                     Html.map OSMsg (OS.view data model)
 

--- a/src/Game/Data.elm
+++ b/src/Game/Data.elm
@@ -6,7 +6,6 @@ module Game.Data
         , getGame
         , fromGateway
         , fromEndpoint
-        , fromActiveServer
         , fromServerID
         )
 
@@ -48,13 +47,6 @@ fromEndpoint : Model -> Maybe Data
 fromEndpoint model =
     model
         |> getEndpoint
-        |> Maybe.map (fromServer model)
-
-
-fromActiveServer : Model -> Maybe Data
-fromActiveServer model =
-    model
-        |> getActiveServer
         |> Maybe.map (fromServer model)
 
 

--- a/src/Game/Meta/Messages.elm
+++ b/src/Game/Meta/Messages.elm
@@ -3,6 +3,7 @@ module Game.Meta.Messages exposing (Msg(..), Context(..))
 import Time exposing (Time)
 import Events.Events as Events
 import Game.Servers.Shared as Servers
+import Game.Network.Types as Network
 
 
 type Context
@@ -12,6 +13,7 @@ type Context
 
 type Msg
     = SetGateway Servers.ID
+    | SetEndpoint (Maybe Network.IP)
     | ContextTo Context
     | Event Events.Response
     | Tick Time

--- a/src/Game/Meta/Update.elm
+++ b/src/Game/Meta/Update.elm
@@ -1,8 +1,10 @@
-module Game.Meta.Update exposing (..)
+module Game.Meta.Update exposing (update)
 
 import Core.Dispatch as Dispatch exposing (Dispatch)
 import Game.Messages as Game
 import Game.Models as Game
+import Game.Servers.Messages as Servers
+import Game.Servers.Models as Servers
 import Game.Meta.Messages exposing (..)
 import Game.Meta.Models exposing (..)
 
@@ -13,17 +15,42 @@ update game msg model =
         SetGateway id ->
             if List.member id game.account.servers then
                 let
-                    model_ =
+                    model1 =
                         { model | gateway = Just id }
+
+                    model_ =
+                        ensureValidContext game model1
                 in
                     ( model_, Cmd.none, Dispatch.none )
             else
                 ( model, Cmd.none, Dispatch.none )
 
+        SetEndpoint ip ->
+            let
+                setEndpoint id =
+                    Dispatch.servers <| Servers.SetEndpoint id ip
+
+                dispatch =
+                    model
+                        |> getGateway
+                        |> Maybe.map setEndpoint
+                        |> Maybe.withDefault Dispatch.none
+
+                model_ =
+                    if ip == Nothing then
+                        ensureValidContext game { model | context = Gateway }
+                    else
+                        ensureValidContext game model
+            in
+                ( model_, Cmd.none, dispatch )
+
         ContextTo context ->
             let
-                model_ =
+                model1 =
                     { model | context = context }
+
+                model_ =
+                    ensureValidContext game model1
             in
                 ( model_, Cmd.none, Dispatch.none )
 
@@ -36,3 +63,23 @@ update game msg model =
 
         _ ->
             ( model, Cmd.none, Dispatch.none )
+
+
+ensureValidContext : Game.Model -> Model -> Model
+ensureValidContext game model =
+    let
+        servers =
+            Game.getServers game
+
+        endpoint =
+            model
+                |> getGateway
+                |> Maybe.andThen (flip Servers.get servers)
+                |> Maybe.andThen Servers.getEndpoint
+                |> Maybe.andThen (flip Servers.mapNetwork servers)
+                |> Maybe.andThen (flip Servers.get servers)
+    in
+        if getContext model == Endpoint && endpoint == Nothing then
+            { model | context = Gateway }
+        else
+            model

--- a/src/OS/Header/Update.elm
+++ b/src/OS/Header/Update.elm
@@ -78,19 +78,6 @@ update data msg ({ openMenu } as model) =
 
         SelectEndpoint ip ->
             let
-                context =
-                    data
-                        |> Game.getGame
-                        |> Game.getMeta
-                        |> (.context)
-
-                id =
-                    data
-                        |> Game.getGame
-                        |> Game.fromGateway
-                        |> Maybe.withDefault data
-                        |> Game.getID
-
                 ip_ =
                     if ip == "" then
                         Nothing
@@ -98,23 +85,12 @@ update data msg ({ openMenu } as model) =
                         Just ip
 
                 dispatch =
-                    Dispatch.servers <| Servers.SetEndpoint id ip_
-
-                dispatch_ =
-                    case ( context, ip_ ) of
-                        ( Meta.Endpoint, Nothing ) ->
-                            Dispatch.batch
-                                [ Dispatch.meta <| Meta.ContextTo Meta.Gateway
-                                , dispatch
-                                ]
-
-                        _ ->
-                            dispatch
+                    Dispatch.meta <| Meta.SetEndpoint ip_
 
                 model_ =
                     { model | openMenu = NothingOpen }
             in
-                ( model_, Cmd.none, dispatch_ )
+                ( model_, Cmd.none, dispatch )
 
         CheckMenus ->
             let
@@ -128,17 +104,7 @@ update data msg ({ openMenu } as model) =
 
         ContextTo context ->
             let
-                endpoint =
-                    data
-                        |> Game.getServer
-                        |> Servers.getEndpoint
-
                 dispatch =
-                    case ( endpoint, context ) of
-                        ( Nothing, Meta.Endpoint ) ->
-                            Dispatch.none
-
-                        _ ->
-                            Dispatch.meta <| Meta.ContextTo context
+                    Dispatch.meta <| Meta.ContextTo context
             in
                 ( model, Cmd.none, dispatch )

--- a/src/OS/SessionManager/Dock/Update.elm
+++ b/src/OS/SessionManager/Dock/Update.elm
@@ -5,6 +5,7 @@ import Game.Data as Game
 import Game.Servers.Models as Servers
 import OS.SessionManager.Dock.Messages exposing (..)
 import OS.SessionManager.Models exposing (..)
+import OS.SessionManager.Helpers exposing (..)
 import OS.SessionManager.WindowManager.Models as WM
 
 
@@ -14,48 +15,52 @@ update :
     -> Model
     -> Model
 update data msg ({ sessions } as model) =
-    case msg of
-        OpenApp app ->
-            let
-                ip =
-                    data
-                        |> Game.getServer
-                        |> Servers.getEndpoint
+    let
+        id =
+            toSessionID data
+    in
+        case msg of
+            OpenApp app ->
+                let
+                    ip =
+                        data
+                            |> Game.getServer
+                            |> Servers.getEndpoint
 
-                model_ =
-                    openApp data.id ip app model
-            in
-                model_
+                    model_ =
+                        openApp id ip app model
+                in
+                    model_
 
-        AppButton app ->
-            let
-                ip =
-                    data
-                        |> Game.getServer
-                        |> Servers.getEndpoint
+            AppButton app ->
+                let
+                    ip =
+                        data
+                            |> Game.getServer
+                            |> Servers.getEndpoint
 
-                model_ =
-                    openOrRestoreApp data.id ip app model
-            in
-                model_
+                    model_ =
+                        openOrRestoreApp id ip app model
+                in
+                    model_
 
-        _ ->
-            case Dict.get data.id sessions of
-                Just wm ->
-                    let
-                        sessions_ =
-                            Dict.insert
-                                data.id
-                                (wmUpdate msg wm)
-                                sessions
+            _ ->
+                case Dict.get id sessions of
+                    Just wm ->
+                        let
+                            sessions_ =
+                                Dict.insert
+                                    id
+                                    (wmUpdate msg wm)
+                                    sessions
 
-                        model_ =
-                            { model | sessions = sessions_ }
-                    in
-                        model_
+                            model_ =
+                                { model | sessions = sessions_ }
+                        in
+                            model_
 
-                Nothing ->
-                    model
+                    Nothing ->
+                        model
 
 
 

--- a/src/OS/SessionManager/Dock/View.elm
+++ b/src/OS/SessionManager/Dock/View.elm
@@ -6,7 +6,8 @@ import Html.Events exposing (onClick)
 import Utils.Html.Attributes exposing (..)
 import Html.CssHelpers
 import OS.Resources as OsRes
-import OS.SessionManager.Models as SessionManager exposing (..)
+import OS.SessionManager.Models exposing (..)
+import OS.SessionManager.Helpers exposing (..)
 import OS.SessionManager.Dock.Messages exposing (..)
 import OS.SessionManager.Dock.Resources as Res
 import OS.SessionManager.WindowManager.Models as WM
@@ -27,7 +28,7 @@ osClass =
     .class <| Html.CssHelpers.withNamespace OsRes.prefix
 
 
-view : GameData.Data -> SessionManager.Model -> Html Msg
+view : GameData.Data -> Model -> Html Msg
 view game model =
     div [ osClass [ OsRes.Dock ] ]
         [ dock game model ]
@@ -40,9 +41,12 @@ view game model =
 dock : GameData.Data -> Model -> Html Msg
 dock data ({ sessions } as model) =
     let
+        id =
+            toSessionID data
+
         wm =
             sessions
-                |> Dict.get data.id
+                |> Dict.get id
                 |> Maybe.withDefault WM.initialModel
 
         content =

--- a/src/OS/SessionManager/Helpers.elm
+++ b/src/OS/SessionManager/Helpers.elm
@@ -1,0 +1,27 @@
+module OS.SessionManager.Helpers exposing (toSessionID)
+
+import Game.Data as Game
+import Game.Meta.Messages as Meta
+import Game.Meta.Models as Meta
+import Game.Models as Game
+import Game.Servers.Models as Servers
+import OS.SessionManager.Models exposing (..)
+
+
+toSessionID : Game.Data -> ID
+toSessionID data =
+    let
+        game =
+            Game.getGame data
+    in
+        case Meta.getContext <| Game.getMeta game of
+            Meta.Gateway ->
+                data.id
+
+            Meta.Endpoint ->
+                data
+                    |> Game.getServer
+                    |> Servers.getEndpoint
+                    |> Maybe.andThen
+                        (flip Servers.mapNetwork <| Game.getServers game)
+                    |> Maybe.withDefault data.id

--- a/src/OS/SessionManager/Subscriptions.elm
+++ b/src/OS/SessionManager/Subscriptions.elm
@@ -2,6 +2,7 @@ module OS.SessionManager.Subscriptions exposing (..)
 
 import OS.SessionManager.Models exposing (..)
 import OS.SessionManager.Messages exposing (..)
+import OS.SessionManager.Helpers exposing (..)
 import OS.SessionManager.WindowManager.Models as WindowManager
 import OS.SessionManager.WindowManager.Subscriptions as WindowManager
 import Game.Data as GameData
@@ -13,9 +14,12 @@ import Game.Data as GameData
 subscriptions : GameData.Data -> Model -> Sub Msg
 subscriptions data model =
     let
+        id =
+            toSessionID data
+
         windowManagerSub =
             model
-                |> get data.id
+                |> get id
                 |> Maybe.map (windowManager data)
                 |> defaultNone
     in

--- a/src/OS/SessionManager/Update.elm
+++ b/src/OS/SessionManager/Update.elm
@@ -2,6 +2,7 @@ module OS.SessionManager.Update exposing (update)
 
 import OS.SessionManager.Models exposing (..)
 import OS.SessionManager.Messages exposing (..)
+import OS.SessionManager.Helpers exposing (..)
 import OS.SessionManager.Dock.Update as Dock
 import OS.SessionManager.WindowManager.Update as WM
 import OS.SessionManager.WindowManager.Models as WM
@@ -17,12 +18,15 @@ update :
     -> ( Model, Cmd Msg, Dispatch )
 update data msg model =
     let
+        id =
+            toSessionID data
+
         model_ =
-            ensureSession data model
+            ensureSession id model
     in
         case msg of
             WindowManagerMsg msg ->
-                windowManager data msg model_
+                windowManager data id msg model_
 
             DockMsg msg ->
                 ( Dock.update data msg model_, Cmd.none, Dispatch.none )
@@ -34,21 +38,22 @@ update data msg model =
 
 windowManager :
     GameData.Data
+    -> ID
     -> WM.Msg
     -> Model
     -> ( Model, Cmd Msg, Dispatch )
-windowManager data msg model =
+windowManager data id msg model =
     let
         wm =
             model
-                |> get data.id
+                |> get id
                 |> Maybe.withDefault WM.initialModel
 
         ( wm_, cmd, dispatch ) =
             WM.update data msg wm
 
         model_ =
-            refresh data.id wm_ model
+            refresh id wm_ model
 
         cmd_ =
             Cmd.map WindowManagerMsg cmd
@@ -56,11 +61,11 @@ windowManager data msg model =
         ( model_, cmd_, dispatch )
 
 
-ensureSession : GameData.Data -> Model -> Model
-ensureSession data model =
-    case get data.id model of
+ensureSession : ID -> Model -> Model
+ensureSession id model =
+    case get id model of
         Just _ ->
             model
 
         Nothing ->
-            insert data.id model
+            insert id model

--- a/src/OS/SessionManager/View.elm
+++ b/src/OS/SessionManager/View.elm
@@ -7,6 +7,7 @@ import Dict
 import OS.Resources as OsRes
 import OS.SessionManager.Models exposing (..)
 import OS.SessionManager.Messages exposing (..)
+import OS.SessionManager.Helpers exposing (..)
 import OS.SessionManager.WindowManager.View as WM
 import OS.SessionManager.WindowManager.Resources as WmRes
 import OS.SessionManager.Dock.View as Dock
@@ -44,11 +45,15 @@ viewDock game model =
 
 viewWM : GameData.Data -> Model -> Html Msg
 viewWM data model =
-    case Dict.get data.id model.sessions of
-        Just wm ->
-            wm
-                |> WM.view data
-                |> Html.map WindowManagerMsg
+    let
+        id =
+            toSessionID data
+    in
+        case Dict.get id model.sessions of
+            Just wm ->
+                wm
+                    |> WM.view data
+                    |> Html.map WindowManagerMsg
 
-        Nothing ->
-            div [ wmClass [ WmRes.Canvas ] ] []
+            Nothing ->
+                div [ wmClass [ WmRes.Canvas ] ] []


### PR DESCRIPTION
- Removes the concept of Active Game.Data (that was confusing);
- Moves gateway/endpoint change logic to Meta (it's the central hub for those changes);
- Blocks changing bounces while connected to some endpoint;
- These changes will ensure that the header is always valid.

**PS:** I wanted to split that over many commits, but my "minimal amount of invalid commits" instinct didn't let me do that.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/heborn/164)
<!-- Reviewable:end -->
