### PR TITLE
[POC] Better Events

### DIFF
--- a/src/Core/Update.elm
+++ b/src/Core/Update.elm
@@ -197,7 +197,7 @@ websocket msg ({ state } as model) =
             case websocket of
                 Just websocket ->
                     let
-                        ( websocket_, cmd ) =
+                        ( websocket_, cmd, dispatch ) =
                             Ws.update msg websocket
 
                         home_ =
@@ -209,14 +209,14 @@ websocket msg ({ state } as model) =
                         model_ =
                             { model | state = Home home_ }
                     in
-                        ( model_, cmd_ )
+                        dispatcher model_ cmd_ dispatch
 
                 Nothing ->
                     ( model, Cmd.none )
 
         Play ({ websocket } as play) ->
             let
-                ( websocket_, cmd ) =
+                ( websocket_, cmd, dispatch ) =
                     Ws.update msg websocket
 
                 play_ =
@@ -228,11 +228,11 @@ websocket msg ({ state } as model) =
                 model_ =
                     { model | state = Play play_ }
             in
-                ( model_, cmd_ )
+                dispatcher model_ cmd_ dispatch
 
         Setup ({ websocket } as setup) ->
             let
-                ( websocket_, cmd ) =
+                ( websocket_, cmd, dispatch ) =
                     Ws.update msg websocket
 
                 setup_ =
@@ -244,7 +244,7 @@ websocket msg ({ state } as model) =
                 model_ =
                     { model | state = Setup setup_ }
             in
-                ( model_, cmd_ )
+                dispatcher model_ cmd_ dispatch
 
 
 game : Game.Msg -> Model -> ( Model, Cmd Msg )

--- a/src/Driver/Websocket/Messages.elm
+++ b/src/Driver/Websocket/Messages.elm
@@ -7,5 +7,5 @@ import Json.Encode exposing (Value)
 
 type Msg
     = JoinChannel Channel (Maybe String)
-    | NewEvent Events.Event Value
-    | Broadcast Events.Response
+    | NewEvent Channel Value
+    | Broadcast Events.Event

--- a/src/Driver/Websocket/Models.elm
+++ b/src/Driver/Websocket/Models.elm
@@ -1,4 +1,4 @@
-module Driver.Websocket.Models exposing (Model, initialModel, eventsFromChannel)
+module Driver.Websocket.Models exposing (Model, initialModel)
 
 import Driver.Websocket.Channels exposing (..)
 import Driver.Websocket.Messages exposing (..)
@@ -9,20 +9,10 @@ import Phoenix.Socket as Socket
 import Phoenix.Channel as Channel
 
 
-type alias Events =
-    List ( String, Event )
-
-
-type alias EventsByChannel =
-    { account : Events
-    }
-
-
 type alias Model =
     { socket : Socket.Socket Msg
     , channels : List (Channel.Channel Msg)
     , defer : Bool
-    , events : EventsByChannel
     }
 
 
@@ -40,26 +30,9 @@ initialChannels =
     [ Channel.init "requests" ]
 
 
-initialEvents : EventsByChannel
-initialEvents =
-    { account = Events.map AccountEvent AccountEvents.events
-    }
-
-
 initialModel : String -> String -> Model
 initialModel apiWsUrl token =
     { socket = initialSocket apiWsUrl token
     , channels = initialChannels
     , defer = True
-    , events = initialEvents
     }
-
-
-eventsFromChannel : Channel -> Model -> List ( String, Event )
-eventsFromChannel channel model =
-    case channel of
-        AccountChannel ->
-            model.events.account
-
-        _ ->
-            []

--- a/src/Events/Account.elm
+++ b/src/Events/Account.elm
@@ -1,36 +1,16 @@
-module Events.Account
-    exposing
-        ( Model
-        , Event(..)
-        , Response(..)
-        , events
-        , handler
-        )
+module Events.Account exposing (Event(..), handler)
 
 import Json.Encode exposing (Value)
 
 
 type Event
-    = Event
+    = NoOp
 
 
-type alias Model =
-    List ( String, Event )
-
-
-type Response
-    = EventResponse
-
-
-events : Model
-events =
-    [ ( "event", Event ) ]
-
-
-handler : Event -> Value -> Response
+handler : String -> Value -> Event
 handler event value =
     case event of
-        Event ->
+        _ ->
             eventHandler value
 
 
@@ -38,6 +18,6 @@ handler event value =
 -- internals
 
 
-eventHandler : Value -> Response
+eventHandler : Value -> Event
 eventHandler value =
-    EventResponse
+    NoOp

--- a/src/Events/Events.elm
+++ b/src/Events/Events.elm
@@ -1,5 +1,6 @@
-module Events.Events exposing (Event(..), Response(..), map, handler)
+module Events.Events exposing (Event(..), handler)
 
+import Driver.Websocket.Channels as Ws
 import Driver.Websocket.Reports as Ws
 import Events.Account as Account
 import Json.Encode exposing (Value)
@@ -7,22 +8,19 @@ import Json.Encode exposing (Value)
 
 type Event
     = AccountEvent Account.Event
-
-
-type Response
-    = AccountEventResponse Account.Response
+    | ServerEvent
+    | RequestsEvent
     | Report Ws.Report
 
 
-map : (a -> b) -> List ( String, a ) -> List ( String, b )
-map mapper events =
-    List.map (\( name, event ) -> ( name, mapper event )) events
+handler : Ws.Channel -> String -> Value -> Event
+handler channel event value =
+    case channel of
+        Ws.AccountChannel ->
+            AccountEvent <| Account.handler event value
 
+        Ws.RequestsChannel ->
+            RequestsEvent
 
-handler : Event -> Value -> Response
-handler event value =
-    case event of
-        AccountEvent event ->
-            value
-                |> Account.handler event
-                |> AccountEventResponse
+        Ws.ServerChannel ->
+            ServerEvent

--- a/src/Game/Account/Messages.elm
+++ b/src/Game/Account/Messages.elm
@@ -9,7 +9,7 @@ type Msg
     = Logout
     | BouncesMsg Bounces.Msg
     | Request RequestMsg
-    | Event Events.Response
+    | Event Events.Event
 
 
 type RequestMsg

--- a/src/Game/Account/Update.elm
+++ b/src/Game/Account/Update.elm
@@ -81,7 +81,7 @@ response game response model =
 
 event :
     Game.Model
-    -> Events.Response
+    -> Events.Event
     -> Model
     -> ( Model, Cmd Msg, Dispatch )
 event game ev model =

--- a/src/Game/Messages.elm
+++ b/src/Game/Messages.elm
@@ -12,5 +12,5 @@ type Msg
     | ServersMsg Servers.Msg
     | MetaMsg Meta.Msg
     | WebMsg Web.Msg
-    | Event Events.Response
+    | Event Events.Event
     | NoOp

--- a/src/Game/Meta/Messages.elm
+++ b/src/Game/Meta/Messages.elm
@@ -11,5 +11,5 @@ type Msg
     = SetGateway Servers.ID
     | SetEndpoint (Maybe NIP)
     | ContextTo Context
-    | Event Events.Response
+    | Event Events.Event
     | Tick Time

--- a/src/Game/Servers/Messages.elm
+++ b/src/Game/Servers/Messages.elm
@@ -19,7 +19,7 @@ type Msg
     | ProcessMsg ID Processes.Msg
     | TunnelsMsg ID Tunnels.Msg
     | Request RequestMsg
-    | Event Events.Response
+    | Event Events.Event
 
 
 type RequestMsg

--- a/src/Game/Web/Messages.elm
+++ b/src/Game/Web/Messages.elm
@@ -8,7 +8,7 @@ type Msg
     = Load String
     | Refresh String
     | Request RequestMsg
-    | Event Events.Response
+    | Event Events.Event
 
 
 type RequestMsg

--- a/src/Game/Web/Update.elm
+++ b/src/Game/Web/Update.elm
@@ -74,7 +74,7 @@ response game response model =
 
 event :
     Game.Model
-    -> Events.Response
+    -> Events.Event
     -> Model
     -> ( Model, Cmd Msg, Dispatch )
 event game ev model =

--- a/src/Setup/Messages.elm
+++ b/src/Setup/Messages.elm
@@ -9,7 +9,7 @@ type Msg
     = MapClick Value
     | GeoLocResp Value
     | GeoRevResp Value
-    | Event Events.Response
+    | Event Events.Event
     | ResetLoc
     | GoStep Step
     | GoOS


### PR DESCRIPTION
I know it's obvious, but please **do not merge this** (yet).
It's a proof of concept that shows how using a single event name simplifies the event handler.

#### CHANGES

- Removes the Event union
- Renames the EventResponse union to Event
- Removes events from Websocket model
- Adds channel context to events (this needs to be added even if we don't use this PR)
- Remove functions that became useless with the change.
- Update the POC event name matcher to reflect the change.
- Update Websocket.Update to broadcast events.
- Update Core.Update to handle Websocket.Update dispatchs.

--- 

I'm waiting for @renatomassaro's **OK**, but I don't want to ask his revision (otherwise this would take 14 days to merge :joy:)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/heborn/192)
<!-- Reviewable:end -->
