### PR TITLE
Add to LogViewer scroll and sort properly

### DIFF
--- a/src/Apps/LogViewer/Models.elm
+++ b/src/Apps/LogViewer/Models.elm
@@ -87,8 +87,8 @@ catchDataWhenFiltering filterCache log =
         Nothing
 
 
-applyFilter : Model -> Logs.Model -> Dict Logs.ID Logs.Log
-applyFilter model =
+applyFilter : Model -> Logs.Model -> Logs.Model
+applyFilter model logs =
     let
         filterer id log =
             if String.length model.filterText > 0 then
@@ -98,7 +98,7 @@ applyFilter model =
             else
                 True
     in
-        Logs.filter filterer
+        { logs | logs = Logs.filter filterer logs }
 
 
 enterEditing : Game.Data -> Logs.ID -> Model -> Model
@@ -110,7 +110,7 @@ enterEditing data id model =
                 |> Servers.getLogs
 
         model_ =
-            case Dict.get id logs of
+            case Dict.get id logs.logs of
                 Just log ->
                     case Logs.getContent log of
                         Logs.NormalContent data ->

--- a/src/Apps/LogViewer/View.elm
+++ b/src/Apps/LogViewer/View.elm
@@ -76,10 +76,9 @@ encrypted =
     "⠽⠕⠥ ⠚⠥⠎⠞ ⠇⠕⠎⠞ ⠠⠠⠞⠓⠑ ⠠⠠⠛⠁⠍⠑"
 
 
-renderEntries : Model -> Dict Logs.ID Logs.Log -> List (Html Msg)
+renderEntries : Model -> Logs.Model -> List (Html Msg)
 renderEntries model logs =
-    logs
-        |> Dict.toList
+    getLogsfromDate logs
         |> List.map (uncurry <| renderEntry model)
 
 
@@ -254,6 +253,26 @@ menuInclude id log model =
 
             Logs.Encrypted ->
                 [ menuEncryptedEntry id ]
+
+
+getLogsfromDateHelper :
+    Dict Logs.ID Logs.Log
+    -> Logs.Date
+    -> Logs.ID
+    -> List ( Logs.ID, Logs.Log )
+    -> List ( Logs.ID, Logs.Log )
+getLogsfromDateHelper logs k v a =
+    case Dict.get v logs of
+        Just log ->
+            a ++ [ ( v, log ) ]
+
+        Nothing ->
+            a
+
+
+getLogsfromDate : Logs.Model -> List ( Logs.ID, Logs.Log )
+getLogsfromDate logs =
+    Dict.foldr (getLogsfromDateHelper logs.logs) [] logs.drawOrder
 
 
 render : Logs.Data -> List (Html Msg)

--- a/src/Css/Utils.elm
+++ b/src/Css/Utils.elm
@@ -1,5 +1,7 @@
 module Css.Utils exposing (..)
 
+import Html
+import Html.Attributes as Attributes exposing (style)
 import Css exposing (..)
 
 
@@ -101,3 +103,8 @@ nest ns i =
 child : (List Style -> Snippet) -> List Style -> Style
 child selector styles =
     children <| List.singleton (selector styles)
+
+
+styles : List Css.Style -> Html.Attribute msg
+styles =
+    Css.asPairs >> style

--- a/src/Decoders/Logs.elm
+++ b/src/Decoders/Logs.elm
@@ -1,7 +1,18 @@
 module Decoders.Logs exposing (..)
 
 import Dict exposing (Dict)
-import Json.Decode as Decode exposing (Decoder, map, oneOf, succeed, string, float, list)
+import Json.Decode as Decode
+    exposing
+        ( Decoder
+        , map
+        , oneOf
+        , succeed
+        , string
+        , float
+        , list
+        , andThen
+        )
+import Time exposing (Time)
 import Json.Decode.Pipeline exposing (decode, required, optional, custom, hardcoded)
 import Game.Servers.Logs.Models exposing (..)
 
@@ -16,7 +27,19 @@ type alias LogWithIndex =
 
 model : Decoder Model
 model =
-    map Dict.fromList index
+    let
+        logs =
+            map Dict.fromList index
+
+        drawOrder =
+            map (Dict.foldl reducer Dict.empty) logs
+
+        reducer id log acu =
+            Dict.insert (findId ( log.timestamp, 0 ) acu) id acu
+    in
+        decode Model
+            |> custom logs
+            |> custom drawOrder
 
 
 index : Decoder Index

--- a/src/UI/Style.elm
+++ b/src/UI/Style.elm
@@ -171,8 +171,10 @@ verticalSticked =
             , typeSelector "mainCont"
                 [ flex (int 1)
                 , flexContainerVert
+                , overflow hidden
                 ]
             ]
+        , maxHeight (pct 100)
         ]
 
 


### PR DESCRIPTION
Closes #339 

* Add Scroll to LogViewer app
* Fix Logs sorting to respect their timestamp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/heborn/342)
<!-- Reviewable:end -->
