### PR TITLE
Replace Game.Model with Configs

### DIFF
--- a/src/Core/Config.elm
+++ b/src/Core/Config.elm
@@ -1,21 +1,10 @@
-module Core.Config exposing (Config, init, getVersion)
+module Core.Config exposing (..)
+
+import Game.Config as Game
+import Core.Messages exposing (..)
 
 
-type alias Config =
-    { apiHttpUrl : String
-    , apiWsUrl : String
-    , version : String
+gameConfig : Game.Config Msg
+gameConfig =
+    { toMsg = GameMsg
     }
-
-
-init : String -> String -> String -> Config
-init apiHttpUrl apiWsUrl version =
-    { apiHttpUrl = apiHttpUrl
-    , apiWsUrl = apiWsUrl
-    , version = version
-    }
-
-
-getVersion : Config -> String
-getVersion =
-    .version

--- a/src/Core/Flags.elm
+++ b/src/Core/Flags.elm
@@ -1,0 +1,21 @@
+module Core.Flags exposing (Flags, initFlags, getVersion)
+
+
+type alias Flags =
+    { apiHttpUrl : String
+    , apiWsUrl : String
+    , version : String
+    }
+
+
+initFlags : String -> String -> String -> Flags
+initFlags apiHttpUrl apiWsUrl version =
+    { apiHttpUrl = apiHttpUrl
+    , apiWsUrl = apiWsUrl
+    , version = version
+    }
+
+
+getVersion : Flags -> String
+getVersion =
+    .version

--- a/src/Core/Update.elm
+++ b/src/Core/Update.elm
@@ -1,9 +1,5 @@
 module Core.Update exposing (update)
 
-import Core.Messages exposing (..)
-import Core.Models exposing (..)
-import Core.Subscribers as Subscribers
-import Core.Dispatch as Dispatch exposing (Dispatch)
 import Driver.Websocket.Messages as Ws
 import Driver.Websocket.Models as Ws
 import Driver.Websocket.Update as Ws
@@ -22,6 +18,11 @@ import OS.SessionManager.WindowManager.Messages as WM
 import OS.SessionManager.Messages as SM
 import Apps.Messages as Apps
 import Apps.TaskManager.Messages as TaskManager
+import Core.Config exposing (..)
+import Core.Dispatch as Dispatch exposing (Dispatch)
+import Core.Messages exposing (..)
+import Core.Models exposing (..)
+import Core.Subscribers as Subscribers
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -315,14 +316,7 @@ updateLanding msg model ({ landing } as stateModel) =
 
 updateGame : Game.Msg -> Game.Model -> ( Game.Model, Cmd Msg, Dispatch )
 updateGame msg model =
-    let
-        ( model_, cmd, dispatch ) =
-            Game.update msg model
-
-        cmd_ =
-            Cmd.map GameMsg cmd
-    in
-        ( model_, cmd_, dispatch )
+    Game.update gameConfig msg model
 
 
 updateWebsocket : Ws.Msg -> Ws.Model -> ( Ws.Model, Cmd Msg, Dispatch )
@@ -345,7 +339,7 @@ isDev : Model -> Bool
 isDev model =
     let
         { version } =
-            getConfig model
+            getFlags model
     in
         -- make this function return False to test the game on production mode
         version == "dev"

--- a/src/Decoders/Bootstrap.elm
+++ b/src/Decoders/Bootstrap.elm
@@ -54,9 +54,9 @@ toModel game got =
             game
                 |> Game.getWeb
 
-        config =
+        flags =
             game
-                |> Game.getConfig
+                |> Game.getFlags
     in
         Game.Model
             account
@@ -64,7 +64,7 @@ toModel game got =
             meta
             got.story
             web
-            config
+            flags
 
 
 joinIndexes : ServerIndex -> GenericServers

--- a/src/Decoders/Game.elm
+++ b/src/Decoders/Game.elm
@@ -77,7 +77,7 @@ bootstrap game =
         |> hardcoded game.meta
         |> required "storyline" Decoders.Storyline.story
         |> hardcoded game.web
-        |> hardcoded game.config
+        |> hardcoded game.flags
         |> hardcoded game.backfeed
         |> map (,)
         |> andThen (\done -> map done <| servers)

--- a/src/Game/Account/Requests/Logout.elm
+++ b/src/Game/Account/Requests/Logout.elm
@@ -5,10 +5,10 @@ import Game.Account.Messages exposing (..)
 import Game.Account.Models exposing (..)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 
 
-request : String -> ID -> ConfigSource a -> Cmd Msg
+request : String -> ID -> FlagsSource a -> Cmd Msg
 request token id =
     let
         payload =

--- a/src/Game/Config.elm
+++ b/src/Game/Config.elm
@@ -1,0 +1,19 @@
+module Game.Config exposing (Config, serversConfig)
+
+import Time exposing (Time)
+import Core.Flags as Core
+import Game.Servers.Config as Servers
+import Game.Messages exposing (..)
+
+
+type alias Config msg =
+    { toMsg : Msg -> msg
+    }
+
+
+serversConfig : Time -> Core.Flags -> Config msg -> Servers.Config msg
+serversConfig lastTick flags config =
+    { flags = flags
+    , toMsg = ServersMsg >> config.toMsg
+    , lastTick = lastTick
+    }

--- a/src/Game/Dummy.elm
+++ b/src/Game/Dummy.elm
@@ -1,17 +1,17 @@
 module Game.Dummy exposing (dummy)
 
-import Core.Config exposing (Config)
+import Core.Flags exposing (Flags)
 import Game.Models exposing (..)
 import Game.Account.Models as Account
 import Game.Servers.Models as Servers
 import Game.Meta.Dummy as Meta
 
 
-dummy : Account.ID -> Account.Username -> Account.Token -> Config -> Model
-dummy id username token config =
+dummy : Account.ID -> Account.Username -> Account.Token -> Flags -> Model
+dummy id username token flags =
     let
         model =
-            initialModel id username token config
+            initialModel id username token flags
 
         account =
             Account.initialModel id username token

--- a/src/Game/Models.elm
+++ b/src/Game/Models.elm
@@ -12,7 +12,7 @@ module Game.Models
         , setMeta
         , getStory
         , setStory
-        , getConfig
+        , getFlags
         , unsafeGetGateway
         , getGateway
         , setGateway
@@ -35,7 +35,7 @@ import Game.Meta.Models as Meta
 import Game.Storyline.Models as Story
 import Game.Web.Models as Web
 import Game.LogStream.Models as LogStream
-import Core.Config exposing (Config)
+import Core.Flags exposing (Flags)
 
 
 type alias Model =
@@ -45,7 +45,7 @@ type alias Model =
     , meta : Meta.Model
     , story : Story.Model
     , web : Web.Model
-    , config : Config
+    , flags : Flags
     , backfeed : LogStream.Model
     }
 
@@ -58,9 +58,9 @@ initialModel :
     Account.ID
     -> Account.Username
     -> Account.Token
-    -> Config
+    -> Flags
     -> Model
-initialModel id username token config =
+initialModel id username token flags =
     { account = Account.initialModel id username token
     , inventory = Inventory.initialModel
     , servers = Servers.initialModel
@@ -68,7 +68,7 @@ initialModel id username token config =
     , story = Story.initialModel
     , web = Web.initialModel
     , backfeed = LogStream.initialModel
-    , config = config
+    , flags = flags
     }
 
 
@@ -136,9 +136,9 @@ setWeb web model =
     { model | web = web }
 
 
-getConfig : Model -> Config
-getConfig =
-    .config
+getFlags : Model -> Flags
+getFlags =
+    .flags
 
 
 

--- a/src/Game/Requests/Resync.elm
+++ b/src/Game/Requests/Resync.elm
@@ -9,7 +9,7 @@ import Decoders.Game
 import Json.Decode exposing (Value, decodeValue)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..), emptyPayload)
+import Requests.Types exposing (FlagsSource, Code(..), emptyPayload)
 import Game.Messages exposing (..)
 import Game.Models exposing (..)
 import Game.Account.Models as Account
@@ -20,7 +20,7 @@ type Response
     = Okay ( Model, ServersToJoin )
 
 
-request : Account.ID -> ConfigSource a -> Cmd Msg
+request : Account.ID -> FlagsSource a -> Cmd Msg
 request id =
     Requests.request (Topics.accountResync id)
         (ResyncRequest >> Request)

--- a/src/Game/Servers/Config.elm
+++ b/src/Game/Servers/Config.elm
@@ -1,0 +1,25 @@
+module Game.Servers.Config exposing (Config, processesConfig)
+
+import Time exposing (Time)
+import Core.Flags as Core
+import Game.Meta.Types.Network as Network exposing (NIP)
+import Game.Servers.Processes.Config as Processes
+import Game.Servers.Messages exposing (..)
+import Game.Servers.Shared exposing (..)
+
+
+type alias Config msg =
+    { flags : Core.Flags
+    , toMsg : Msg -> msg
+    , lastTick : Time
+    }
+
+
+processesConfig : CId -> NIP -> Config msg -> Processes.Config msg
+processesConfig cid nip config =
+    { flags = config.flags
+    , toMsg = ProcessesMsg >> ServerMsg cid >> config.toMsg
+    , cid = cid
+    , nip = nip
+    , lastTick = config.lastTick
+    }

--- a/src/Game/Servers/Filesystem/Requests/Create.elm
+++ b/src/Game/Servers/Filesystem/Requests/Create.elm
@@ -3,7 +3,7 @@ module Game.Servers.Filesystem.Requests.Create exposing (..)
 import Json.Encode as Encode exposing (Value)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Game.Servers.Shared exposing (CId)
 import Game.Servers.Filesystem.Messages exposing (..)
 import Game.Servers.Filesystem.Models exposing (..)
@@ -17,7 +17,7 @@ request :
     -> String
     -> Path
     -> CId
-    -> ConfigSource a
+    -> FlagsSource a
     -> Cmd Msg
 request what newBaseName newPath cid =
     let

--- a/src/Game/Servers/Filesystem/Requests/Delete.elm
+++ b/src/Game/Servers/Filesystem/Requests/Delete.elm
@@ -3,13 +3,13 @@ module Game.Servers.Filesystem.Requests.Delete exposing (..)
 import Json.Encode as Encode exposing (Value)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Game.Servers.Shared exposing (CId)
 import Game.Servers.Filesystem.Messages exposing (..)
 import Game.Servers.Filesystem.Models exposing (..)
 
 
-request : Id -> CId -> ConfigSource a -> Cmd Msg
+request : Id -> CId -> FlagsSource a -> Cmd Msg
 request id cid =
     let
         payload =

--- a/src/Game/Servers/Filesystem/Requests/Move.elm
+++ b/src/Game/Servers/Filesystem/Requests/Move.elm
@@ -3,13 +3,13 @@ module Game.Servers.Filesystem.Requests.Move exposing (..)
 import Json.Encode as Encode exposing (Value)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Game.Servers.Shared exposing (CId)
 import Game.Servers.Filesystem.Messages exposing (..)
 import Game.Servers.Filesystem.Models exposing (..)
 
 
-request : Path -> Id -> CId -> ConfigSource a -> Cmd Msg
+request : Path -> Id -> CId -> FlagsSource a -> Cmd Msg
 request path id cid =
     let
         destination =

--- a/src/Game/Servers/Filesystem/Requests/Rename.elm
+++ b/src/Game/Servers/Filesystem/Requests/Rename.elm
@@ -3,13 +3,13 @@ module Game.Servers.Filesystem.Requests.Rename exposing (..)
 import Json.Encode as Encode exposing (Value)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Game.Servers.Shared exposing (CId)
 import Game.Servers.Filesystem.Messages exposing (..)
 import Game.Servers.Filesystem.Models exposing (..)
 
 
-request : String -> Id -> CId -> ConfigSource a -> Cmd Msg
+request : String -> Id -> CId -> FlagsSource a -> Cmd Msg
 request newBaseName id cid =
     let
         payload =

--- a/src/Game/Servers/Hardware/Requests/UpdateMotherboard.elm
+++ b/src/Game/Servers/Hardware/Requests/UpdateMotherboard.elm
@@ -16,7 +16,7 @@ import Json.Decode as Decode
 import Utils.Json.Decode exposing (commonError)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Game.Servers.Shared exposing (CId)
 import Game.Meta.Types.Components.Motherboard as Motherboard exposing (Motherboard)
 import Game.Servers.Hardware.Messages exposing (..)
@@ -37,7 +37,7 @@ type Response
     | Error
 
 
-request : Motherboard -> CId -> ConfigSource a -> Cmd Msg
+request : Motherboard -> CId -> FlagsSource a -> Cmd Msg
 request motherboard cid =
     Requests.request (Topics.updateMotherboard cid)
         (UpdateMotherboardRequest >> Request)

--- a/src/Game/Servers/Processes/Config.elm
+++ b/src/Game/Servers/Processes/Config.elm
@@ -1,0 +1,16 @@
+module Game.Servers.Processes.Config exposing (Config)
+
+import Time exposing (Time)
+import Core.Flags as Core
+import Game.Servers.Processes.Messages exposing (..)
+import Game.Servers.Shared as Servers exposing (CId)
+import Game.Meta.Types.Network as Network exposing (NIP)
+
+
+type alias Config msg =
+    { flags : Core.Flags
+    , toMsg : Msg -> msg
+    , cid : CId
+    , nip : NIP
+    , lastTick : Time
+    }

--- a/src/Game/Servers/Processes/Requests/Bruteforce.elm
+++ b/src/Game/Servers/Processes/Requests/Bruteforce.elm
@@ -9,7 +9,7 @@ import Json.Encode as Encode
 import Json.Decode exposing (Value, decodeValue)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Game.Meta.Types.Network as Network
 import Game.Servers.Shared exposing (CId)
 import Game.Servers.Processes.Models exposing (..)
@@ -29,7 +29,7 @@ request :
     -> Network.ID
     -> Network.IP
     -> CId
-    -> ConfigSource a
+    -> FlagsSource a
     -> Cmd Msg
 request optimistic network targetIp cid =
     let

--- a/src/Game/Servers/Processes/Requests/Download.elm
+++ b/src/Game/Servers/Processes/Requests/Download.elm
@@ -20,7 +20,7 @@ import Json.Encode as Encode
 import Utils.Json.Decode exposing (commonError)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Game.Servers.Processes.Messages exposing (..)
 import Game.Servers.Filesystem.Models as Filesystem
 import Game.Servers.Processes.Models exposing (ID, Process)
@@ -43,7 +43,7 @@ request :
     -> Filesystem.Id
     -> String
     -> CId
-    -> ConfigSource a
+    -> FlagsSource a
     -> Cmd Msg
 request optmistic target fileId storageId cid =
     Requests.request (Topics.fsDownload cid)
@@ -58,7 +58,7 @@ requestPublic :
     -> Filesystem.Id
     -> String
     -> CId
-    -> ConfigSource a
+    -> FlagsSource a
     -> Cmd Msg
 requestPublic optmistic target fileId storageId cid =
     Requests.request (Topics.pftpDownload cid)

--- a/src/Game/Servers/Requests/Resync.elm
+++ b/src/Game/Servers/Requests/Resync.elm
@@ -9,7 +9,7 @@ import Time exposing (Time)
 import Json.Decode as Decode exposing (Value, decodeValue)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..), emptyPayload)
+import Requests.Types exposing (FlagsSource, Code(..), emptyPayload)
 import Decoders.Servers
 import Game.Servers.Models exposing (..)
 import Game.Servers.Messages
@@ -24,7 +24,7 @@ type Response
     = Okay ( CId, Server )
 
 
-request : Maybe GatewayCache -> CId -> ConfigSource a -> Cmd Msg
+request : Maybe GatewayCache -> CId -> FlagsSource a -> Cmd Msg
 request gatewayCache id =
     -- this request is mainly used to fetch invaded computers
     Requests.request (Topics.serverResync id)

--- a/src/Game/Storyline/Emails/Requests/Reply.elm
+++ b/src/Game/Storyline/Emails/Requests/Reply.elm
@@ -19,7 +19,7 @@ import Json.Encode as Encode
 import Utils.Json.Decode exposing (commonError)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Game.Storyline.Emails.Messages exposing (..)
 
 
@@ -32,7 +32,7 @@ type Response
 request :
     String
     -> String
-    -> ConfigSource a
+    -> FlagsSource a
     -> Cmd Msg
 request accountId replyId =
     Requests.request

--- a/src/Game/Update.elm
+++ b/src/Game/Update.elm
@@ -15,6 +15,7 @@ import Game.Account.Models as Account
 import Game.Account.Update as Account
 import Game.Meta.Messages as Meta
 import Game.Meta.Update as Meta
+import Game.Meta.Models as Meta
 import Game.Servers.Messages as Servers
 import Game.Servers.Update as Servers
 import Game.Servers.Shared as Servers
@@ -30,56 +31,57 @@ import Game.LogStream.Update as LogFlix
 import Game.Meta.Types.Network as Network
 import Game.Requests as Request exposing (Response)
 import Game.Requests.Resync as Resync
-import Game.Models exposing (..)
+import Game.Config exposing (..)
 import Game.Messages exposing (..)
+import Game.Models exposing (..)
 
 
-type alias UpdateResponse =
-    ( Model, Cmd Msg, Dispatch )
+type alias UpdateResponse msg =
+    ( Model, Cmd msg, Dispatch )
 
 
-update : Msg -> Model -> UpdateResponse
-update msg model =
+update : Config msg -> Msg -> Model -> UpdateResponse msg
+update config msg model =
     case msg of
         AccountMsg msg ->
-            onAccount msg model
+            onAccount config msg model
 
         ServersMsg msg ->
-            onServers msg model
+            onServers config msg model
 
         MetaMsg msg ->
-            onMeta msg model
+            onMeta config msg model
 
         StoryMsg msg ->
-            onStory msg model
+            onStory config msg model
 
         InventoryMsg msg ->
-            onInventory msg model
+            onInventory config msg model
 
         WebMsg msg ->
-            onWeb msg model
+            onWeb config msg model
 
         LogFlixMsg msg ->
-            onLogFlix msg model
+            onLogFlix config msg model
 
         Resync ->
-            onResync model
+            onResync config model
 
         Request data ->
             Request.receive model data
-                |> Maybe.map (flip updateRequest model)
+                |> Maybe.map (flip (updateRequest config) model)
                 |> Maybe.withDefault (Update.fromModel model)
 
         HandleJoinedAccount value ->
-            handleJoinedAccount value model
+            handleJoinedAccount config value model
 
 
 
 -- internals
 
 
-onResync : Model -> UpdateResponse
-onResync model =
+onResync : Config msg -> Model -> UpdateResponse msg
+onResync config model =
     let
         accountId =
             model
@@ -87,7 +89,7 @@ onResync model =
                 |> Account.getId
 
         cmd =
-            Resync.request accountId model
+            Cmd.map config.toMsg <| Resync.request accountId model
     in
         ( model, cmd, Dispatch.none )
 
@@ -96,84 +98,96 @@ onResync model =
 -- childs
 
 
-onAccount : Account.Msg -> Model -> UpdateResponse
-onAccount msg game =
+onAccount : Config msg -> Account.Msg -> Model -> UpdateResponse msg
+onAccount config msg game =
     Update.child
         { get = .account
         , set = (\account game -> { game | account = account })
-        , toMsg = AccountMsg
+        , toMsg = AccountMsg >> config.toMsg
         , update = (Account.update game)
         }
         msg
         game
 
 
-onMeta : Meta.Msg -> Model -> UpdateResponse
-onMeta msg game =
+onMeta : Config msg -> Meta.Msg -> Model -> UpdateResponse msg
+onMeta config msg game =
     Update.child
         { get = .meta
         , set = (\meta game -> { game | meta = meta })
-        , toMsg = MetaMsg
+        , toMsg = MetaMsg >> config.toMsg
         , update = (Meta.update game)
         }
         msg
         game
 
 
-onStory : Story.Msg -> Model -> UpdateResponse
-onStory msg game =
+onStory : Config msg -> Story.Msg -> Model -> UpdateResponse msg
+onStory config msg game =
     Update.child
         { get = .story
         , set = (\story game -> { game | story = story })
-        , toMsg = StoryMsg
+        , toMsg = StoryMsg >> config.toMsg
         , update = (Story.update game)
         }
         msg
         game
 
 
-onInventory : Inventory.Msg -> Model -> UpdateResponse
-onInventory msg game =
+onInventory : Config msg -> Inventory.Msg -> Model -> UpdateResponse msg
+onInventory config msg game =
     Update.child
         { get = .inventory
         , set = (\inventory game -> { game | inventory = inventory })
-        , toMsg = InventoryMsg
+        , toMsg = InventoryMsg >> config.toMsg
         , update = Inventory.update
         }
         msg
         game
 
 
-onWeb : Web.Msg -> Model -> UpdateResponse
-onWeb msg game =
+onWeb : Config msg -> Web.Msg -> Model -> UpdateResponse msg
+onWeb config msg game =
     Update.child
         { get = .web
         , set = (\web game -> { game | web = web })
-        , toMsg = WebMsg
+        , toMsg = WebMsg >> config.toMsg
         , update = (Web.update game)
         }
         msg
         game
 
 
-onServers : Servers.Msg -> Model -> UpdateResponse
-onServers msg game =
-    Update.child
-        { get = .servers
-        , set = (\servers game -> { game | servers = servers })
-        , toMsg = ServersMsg
-        , update = (Servers.update game)
-        }
-        msg
-        game
+
+-- remember to remove Game.Model after refactoring Game.Servers
 
 
-onLogFlix : LogFlix.Msg -> Model -> UpdateResponse
-onLogFlix msg game =
+onServers : Config msg -> Servers.Msg -> Model -> UpdateResponse msg
+onServers config msg model =
+    let
+        lastTick =
+            Meta.getLastTick (getMeta model)
+
+        config_ =
+            serversConfig lastTick
+                (getFlags model)
+                config
+
+        ( servers, cmd, dispatch ) =
+            Servers.update config_ model msg <| getServers model
+
+        model_ =
+            { model | servers = servers }
+    in
+        ( model_, cmd, dispatch )
+
+
+onLogFlix : Config msg -> LogFlix.Msg -> Model -> UpdateResponse msg
+onLogFlix config msg game =
     Update.child
         { get = .backfeed
         , set = (\backfeed game -> { game | backfeed = backfeed })
-        , toMsg = LogFlixMsg
+        , toMsg = LogFlixMsg >> config.toMsg
         , update = (LogFlix.update game)
         }
         msg
@@ -184,15 +198,19 @@ onLogFlix msg game =
 -- requests
 
 
-updateRequest : Response -> Model -> UpdateResponse
-updateRequest response model =
+updateRequest : Config msg -> Response -> Model -> UpdateResponse msg
+updateRequest config response model =
     case response of
         Request.Resync (Resync.Okay data) ->
-            uncurry (flip onResyncResponse) data
+            uncurry (flip <| onResyncResponse config) data
 
 
-onResyncResponse : Decoders.Game.ServersToJoin -> Model -> UpdateResponse
-onResyncResponse servers model =
+onResyncResponse :
+    Config msg
+    -> Decoders.Game.ServersToJoin
+    -> Model
+    -> UpdateResponse msg
+onResyncResponse config servers model =
     let
         dispatch =
             servers.player
@@ -206,8 +224,8 @@ onResyncResponse servers model =
 -- events
 
 
-handleJoinedAccount : Value -> Model -> UpdateResponse
-handleJoinedAccount value model =
+handleJoinedAccount : Config msg -> Value -> Model -> UpdateResponse msg
+handleJoinedAccount config value model =
     case Decode.decodeValue (Decoders.Game.bootstrap model) value of
         Ok ( model_, servers ) ->
             let

--- a/src/Game/Web/Requests/DNS.elm
+++ b/src/Game/Web/Requests/DNS.elm
@@ -30,7 +30,7 @@ import Json.Decode.Pipeline as Encode
 import Json.Encode as Encode
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Decoders.Network
 import Decoders.Filesystem
 import Game.Servers.Shared as Servers
@@ -46,7 +46,7 @@ request :
     -> Network.ID
     -> Servers.CId
     -> Requester
-    -> ConfigSource a
+    -> FlagsSource a
     -> Cmd Msg
 request url networkId cid requester =
     Requests.request (Topics.browse cid)

--- a/src/Landing/Login/Requests/Login.elm
+++ b/src/Landing/Login/Requests/Login.elm
@@ -11,7 +11,7 @@ import Json.Encode as Encode
 import Landing.Login.Messages exposing (..)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 
 
 type Response
@@ -19,7 +19,7 @@ type Response
     | Error
 
 
-request : String -> String -> ConfigSource a -> Cmd Msg
+request : String -> String -> FlagsSource a -> Cmd Msg
 request username password =
     Requests.request Topics.login
         (LoginRequest >> Request)

--- a/src/Landing/SignUp/Requests/SignUp.elm
+++ b/src/Landing/SignUp/Requests/SignUp.elm
@@ -11,7 +11,7 @@ import Json.Encode as Encode
 import Landing.SignUp.Messages exposing (..)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 
 
 type Response
@@ -19,7 +19,7 @@ type Response
     | Error
 
 
-request : String -> String -> String -> ConfigSource a -> Cmd Msg
+request : String -> String -> String -> FlagsSource a -> Cmd Msg
 request email username password =
     Requests.request Topics.register
         (SignUpRequest >> Request)

--- a/src/Landing/View.elm
+++ b/src/Landing/View.elm
@@ -74,7 +74,7 @@ viewLogin model =
 
 viewSignUp : Core.Model -> Model -> Html Msg
 viewSignUp core model =
-    if core.config.version == "dev" then
+    if core.flags.version == "dev" then
         Html.map SignUpMsg (SignUp.view model.signUp)
     else
         div [] []

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -6,7 +6,7 @@ import Core.Messages exposing (..)
 import Core.Models exposing (..)
 import Core.Update exposing (..)
 import Core.View exposing (..)
-import Core.Config as Config exposing (Config)
+import Core.Flags as Core
 
 
 -- import TimeTravel.Navigation
@@ -23,11 +23,11 @@ type alias Flags =
 init : Flags -> ( Model, Cmd Msg )
 init { seed, apiHttpUrl, apiWsUrl, version } =
     let
-        config =
-            Config.init apiHttpUrl apiWsUrl version
+        flags =
+            Core.initFlags apiHttpUrl apiWsUrl version
 
         model =
-            initialModel seed config
+            initialModel seed flags
     in
         ( model, Cmd.none )
 

--- a/src/OS/View.elm
+++ b/src/OS/View.elm
@@ -9,7 +9,7 @@ import Game.Data as Game
 import Game.Models as Game
 import Game.Account.Models as Account
 import Game.Storyline.Models as Storyline
-import Core.Config as Config
+import Core.Flags as Flags
 import OS.Models exposing (Model)
 import OS.Messages exposing (Msg(..))
 import OS.Resources as Res
@@ -41,8 +41,8 @@ view data model =
 
         version =
             game
-                |> Game.getConfig
-                |> Config.getVersion
+                |> Game.getFlags
+                |> Flags.getVersion
 
         context =
             game
@@ -91,8 +91,8 @@ viewOS data model =
         version =
             data
                 |> Game.getGame
-                |> Game.getConfig
-                |> Config.getVersion
+                |> Game.getFlags
+                |> Flags.getVersion
     in
         [ viewHeader
             data

--- a/src/Requests/Requests.elm
+++ b/src/Requests/Requests.elm
@@ -29,7 +29,7 @@ request :
     Topic
     -> (ResponseType -> msg)
     -> Encode.Value
-    -> ConfigSource a
+    -> FlagsSource a
     -> Cmd msg
 request topic msg data source =
     case topic of
@@ -37,14 +37,14 @@ request topic msg data source =
             WebsocketDriver.send
                 (okWs msg)
                 (errorWs msg)
-                source.config.apiWsUrl
+                source.flags.apiWsUrl
                 (WebsocketDriver.getAddress channel)
                 path
                 data
 
         HttpTopic path ->
             HttpDriver.send (genericHttp msg)
-                source.config.apiHttpUrl
+                source.flags.apiHttpUrl
                 path
                 (Encode.encode 0 data)
 

--- a/src/Requests/Types.elm
+++ b/src/Requests/Types.elm
@@ -2,7 +2,7 @@ module Requests.Types
     exposing
         ( Driver(..)
         , Code(..)
-        , ConfigSource
+        , FlagsSource
         , ResponseType
         , WebsocketResponse
         , Context
@@ -12,11 +12,11 @@ module Requests.Types
 
 import Json.Decode exposing (Value)
 import Json.Encode as Encode
-import Core.Config exposing (Config)
+import Core.Flags as Core
 
 
-type alias ConfigSource a =
-    { a | config : Config }
+type alias FlagsSource a =
+    { a | flags : Core.Flags }
 
 
 type alias ResponseType =

--- a/src/Setup/Requests/Check.elm
+++ b/src/Setup/Requests/Check.elm
@@ -4,7 +4,7 @@ import Json.Decode as Decode exposing (Decoder, Value, decodeValue)
 import Json.Encode as Encode
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ConfigSource, Code(..), ResponseType)
+import Requests.Types exposing (FlagsSource, Code(..), ResponseType)
 import Game.Servers.Shared exposing (CId)
 import Utils.Ports.Map exposing (Coordinates)
 import Setup.Settings exposing (..)
@@ -13,7 +13,7 @@ import Setup.Settings exposing (..)
 {- This is a meta/multi request module, use it to build custom requests -}
 
 
-serverName : (Bool -> msg) -> String -> CId -> ConfigSource a -> Cmd msg
+serverName : (Bool -> msg) -> String -> CId -> FlagsSource a -> Cmd msg
 serverName func name cid =
     name
         |> Name
@@ -27,7 +27,7 @@ serverLocation :
     (Maybe String -> msg)
     -> Coordinates
     -> CId
-    -> ConfigSource a
+    -> FlagsSource a
     -> Cmd msg
 serverLocation func coords cid =
     coords

--- a/src/Setup/Requests/SetServer.elm
+++ b/src/Setup/Requests/SetServer.elm
@@ -9,7 +9,7 @@ import Json.Decode as Decode exposing (Value)
 import Json.Encode as Encode
 import Requests.Requests as Requests
 import Requests.Topics as Topics
-import Requests.Types exposing (ResponseType, ConfigSource, Code(..))
+import Requests.Types exposing (ResponseType, FlagsSource, Code(..))
 import Game.Servers.Shared as Servers
 import Setup.Settings exposing (..)
 import Setup.Messages exposing (..)
@@ -19,7 +19,7 @@ type alias Response =
     List Settings
 
 
-request : List Settings -> Servers.CId -> ConfigSource a -> Cmd Msg
+request : List Settings -> Servers.CId -> FlagsSource a -> Cmd Msg
 request settings cid =
     Requests.request (Topics.serverConfigSet cid)
         (SetServerRequest settings >> Request)

--- a/src/Setup/Requests/Setup.elm
+++ b/src/Setup/Requests/Setup.elm
@@ -3,7 +3,7 @@ module Setup.Requests.Setup exposing (Response(..), request, receive)
 import Requests.Requests as Requests
 import Requests.Topics as Topics
 import Json.Encode as Encode exposing (Value)
-import Requests.Types exposing (ConfigSource, Code(..))
+import Requests.Types exposing (FlagsSource, Code(..))
 import Setup.Messages exposing (..)
 import Setup.Models exposing (..)
 import Game.Account.Models as Account
@@ -14,7 +14,7 @@ type Response
     | Error
 
 
-request : List PageModel -> Account.ID -> ConfigSource a -> Cmd Msg
+request : List PageModel -> Account.ID -> FlagsSource a -> Cmd Msg
 request pages id =
     let
         payload =

--- a/tests/Gen/Game.elm
+++ b/tests/Gen/Game.elm
@@ -49,7 +49,7 @@ genModel =
                 LogStream.initialModel
             , inventory =
                 Inventory.initialModel
-            , config =
+            , flags =
                 { apiHttpUrl = ""
                 , apiWsUrl = ""
                 , version = "test"

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -5,6 +5,7 @@ import Core.Dispatch as Dispatch exposing (Dispatch)
 import Core.Subscribers as Subscribers
 import Core.Messages as Core
 import Game.Messages as Game
+import Game.Config as Game
 import Game.Models as Game
 import Game.Update as Game
 import Json.Decode as Decode
@@ -18,6 +19,12 @@ once param =
 
 fuzz param =
     fuzzWith { runs = Config.baseFuzzRuns } param
+
+
+gameConfig : Game.Config Game.Msg
+gameConfig =
+    { toMsg = identity
+    }
 
 
 batch : List Expectation -> Expectation
@@ -48,7 +55,7 @@ updateGame : Game.Msg -> Game.Model -> Game.Model
 updateGame msg0 model0 =
     let
         ( model1, cmd, dispatch ) =
-            Game.update msg0 model0
+            Game.update gameConfig msg0 model0
 
         ( model2, _ ) =
             gameDispatcher model1 cmd dispatch
@@ -106,7 +113,7 @@ gameReducer msg ( model, cmd ) =
         ( model_, cmd_, _ ) =
             case msg of
                 Core.GameMsg msg ->
-                    Game.update msg model
+                    Game.update gameConfig msg model
 
                 _ ->
                     ( model, cmd, Dispatch.none )


### PR DESCRIPTION
- Rename `Core.Config` to `Core.Flags`.
- Implement a proper `Core.Config`.
- Remove `Game.Model` dependency from `Game.Servers.Processses` and use configs instead.
- Adapt `Game.Servers` to comply and use configs while still having support to the older method.
- Adapt `Game` to comply and use configs while still having support to the older method.
- Fix tests.

---

### THIS IS YOUR CONFIG POC, STUDY IT, FEEL IT, BE ONE WITH IT
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/heborn/378)
<!-- Reviewable:end -->
