### PR TITLE
Add await event.

### DIFF
--- a/src/Core/Config.elm
+++ b/src/Core/Config.elm
@@ -256,6 +256,7 @@ osConfig game menu ctx (( sCId, _ ) as srv) (( gCId, gSrv ) as gtw) =
         { flags = Game.getFlags game
         , toMsg = OSMsg
         , batchMsg = BatchMsg
+        , awaitEvent = HandleAwait
         , gameMsg = GameMsg
         , game = game
         , activeContext = ctx

--- a/src/Core/Messages.elm
+++ b/src/Core/Messages.elm
@@ -4,12 +4,17 @@ import ContextMenu
 import Json.Decode exposing (Value)
 import Game.Messages as Game
 import Game.Account.Models as Account
+import Game.Meta.Types.AwaitEvent as AwaitEvent
 import OS.Messages as OS
 import Landing.Messages as Landing
 import Setup.Messages as Setup
 import Driver.Websocket.Channels as Ws
 import Driver.Websocket.Messages as Ws
 import Core.Error as Error exposing (Error)
+
+
+type alias RequestId =
+    String
 
 
 type Msg
@@ -19,7 +24,8 @@ type Msg
     | HandleShutdown
     | HandleCrash Error
     | HandlePlay
-    | HandleEvent Ws.Channel (Result String ( String, Value ))
+    | HandleEvent Ws.Channel (Result String ( String, String, Value ))
+    | HandleAwait AwaitEvent.RequestId Msg
     | LandingMsg Landing.Msg
     | SetupMsg Setup.Msg
     | GameMsg Game.Msg

--- a/src/Core/Models.elm
+++ b/src/Core/Models.elm
@@ -22,6 +22,7 @@ import Driver.Websocket.Launch as Ws
 import Driver.Websocket.Models as Ws
 import Landing.Models as Landing
 import Setup.Models as Setup
+import Game.Meta.Types.AwaitEvent as AwaitEvent exposing (AwaitEvent)
 import Game.Models as Game
 import Game.Account.Models as Account
 import Game.Dummy as Game
@@ -34,6 +35,7 @@ type alias Model =
     , seed : Int
     , windowLoaded : Bool
     , contextMenu : ContextMenuMagic
+    , awaitEvent : AwaitEvent Msg
     }
 
 
@@ -88,6 +90,7 @@ init seed flags =
             , seed = seed
             , windowLoaded = False
             , contextMenu = menuModel
+            , awaitEvent = AwaitEvent.empty
             }
 
         cmd =

--- a/src/Driver/Websocket/Config.elm
+++ b/src/Driver/Websocket/Config.elm
@@ -16,5 +16,5 @@ type alias Config msg =
     , onJoinedServer : CId -> Value -> msg
     , onJoinFailedServer : CId -> msg
     , onLeft : Channel -> Maybe Value -> msg
-    , onEvent : Channel -> Result String ( String, Value ) -> msg
+    , onEvent : Channel -> Result String ( String, String, Value ) -> msg
     }

--- a/src/Driver/Websocket/Update.elm
+++ b/src/Driver/Websocket/Update.elm
@@ -2,7 +2,7 @@ module Driver.Websocket.Update exposing (update)
 
 import Dict exposing (Dict)
 import Json.Decode exposing (Value, decodeValue, value, string, field)
-import Json.Decode.Pipeline exposing (decode, required)
+import Json.Decode.Pipeline exposing (decode, required, optional)
 import Phoenix.Channel as Channel
 import Utils.React as React exposing (React)
 import Driver.Websocket.Config exposing (..)
@@ -159,9 +159,10 @@ decodeJoinFailed =
     decodeValue <| field "data" value
 
 
-decodeEvent : Value -> Result String ( String, Value )
+decodeEvent : Value -> Result String ( String, String, Value )
 decodeEvent =
-    decode (,)
+    decode (,,)
         |> required "event" string
+        |> optional "request_id" string ""
         |> required "data" value
         |> decodeValue

--- a/src/Events/Handler.elm
+++ b/src/Events/Handler.elm
@@ -18,11 +18,11 @@ type alias Error =
 handler :
     Config msg
     -> Ws.Channel
-    -> Result String ( String, Value )
+    -> Result String ( String, String, Value )
     -> Result Error msg
 handler config channel result =
     case result of
-        Ok ( event, value ) ->
+        Ok ( event, requestId, value ) ->
             case router config channel event value of
                 Ok event ->
                     Ok event

--- a/src/Game/Meta/Types/AwaitEvent.elm
+++ b/src/Game/Meta/Types/AwaitEvent.elm
@@ -1,0 +1,35 @@
+module Game.Meta.Types.AwaitEvent
+    exposing
+        ( AwaitEvent
+        , RequestId
+        , empty
+        , subscribe
+        , receive
+        )
+
+import Dict exposing (Dict)
+
+
+type alias AwaitEvent msg =
+    Dict RequestId msg
+
+
+type alias RequestId =
+    String
+
+
+empty : AwaitEvent msg
+empty =
+    Dict.empty
+
+
+subscribe : RequestId -> msg -> AwaitEvent msg -> AwaitEvent msg
+subscribe =
+    Dict.insert
+
+
+receive : RequestId -> AwaitEvent msg -> ( Maybe msg, AwaitEvent msg )
+receive requestId awaitEvent =
+    ( Dict.get requestId awaitEvent
+    , Dict.remove requestId awaitEvent
+    )

--- a/src/OS/Config.elm
+++ b/src/OS/Config.elm
@@ -29,6 +29,7 @@ type alias Config msg =
     { flags : Flags
     , toMsg : Msg -> msg
     , batchMsg : List msg -> msg
+    , awaitEvent : String -> msg -> msg
     , gameMsg : Game.Msg -> msg
     , game : Game.Model
     , activeContext : Context
@@ -45,6 +46,7 @@ windowManagerConfig config =
     { flags = config.flags
     , toMsg = WindowManagerMsg >> config.toMsg
     , batchMsg = config.batchMsg
+    , awaitEvent = config.awaitEvent
     , gameMsg = config.gameMsg
     , game = config.game
     , activeContext = config.activeContext

--- a/src/OS/WindowManager/Config.elm
+++ b/src/OS/WindowManager/Config.elm
@@ -55,6 +55,7 @@ type alias Config msg =
     { flags : Flags
     , toMsg : Msg -> msg
     , batchMsg : List msg -> msg
+    , awaitEvent : String -> msg -> msg
     , gameMsg : Game.Msg -> msg
     , game : Game.Model
     , activeContext : Context

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -32,7 +32,7 @@ applyEvent : String -> String -> Ws.Channel -> Game.Model -> Game.Model
 applyEvent name data channel model =
     let
         result =
-            ( name, toValue data )
+            ( name, "", toValue data )
                 |> Ok
                 |> Events.handler Core.eventsConfig channel
                 |> Result.map React.msg


### PR DESCRIPTION
**Features:**

- Triggers a message when an event of given `request_id` is received.

**Limitations:**

- Won't receive event data.[1]
- For simplicity, one `Msg` per `request_id`, use `config.batchMsg` for multiple messages.
- No `request_id` generation, it's a good idea to add a helper function to do that.

- `[1]` Not possible without an antipattern **OR** slowing HEBorn down a lot by broadcasting events to every `Msg` type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/heborn/463)
<!-- Reviewable:end -->
