### PR TITLE
Fix TaskManager view exception, closes #493

### DIFF
--- a/src/Apps/TaskManager/View.elm
+++ b/src/Apps/TaskManager/View.elm
@@ -226,15 +226,18 @@ viewGraphUsage title color history =
         sz =
             toFloat ((List.length history) - 1)
 
+        nanToZero num =
+            if isNaN num then
+                0
+            else
+                num
+
         points =
-            (List.indexedMap
-                (\i x ->
-                    ( (1 - toFloat (i) / sz)
+            (flip List.indexedMap history) <|
+                \i x ->
+                    ( nanToZero (1 - toFloat (i) / sz)
                     , (1 - x)
                     )
-                )
-                history
-            )
     in
         lineGraph points color 50 True ( 3, 1 )
 


### PR DESCRIPTION
Explaining:

It wasn't Chrome's fault, it's Firefox that is less noisy with using `NaN`s for SVG coordinates, which is invalid btw.

This PR introduces a fallback from `NaN` to zero, and yes, dividing by zero is what was causing that NaN in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hackerexperience/heborn/499)
<!-- Reviewable:end -->
