### PR TITLE
Extends Leaflet port with shapes

### DIFF
--- a/src/OS/Map/Messages.elm
+++ b/src/OS/Map/Messages.elm
@@ -5,5 +5,5 @@ import Utils.Ports.Geolocation as Geolocation
 
 
 type Msg
-    = LeafletMsg Leaflet.Msg
+    = LeafletMsg Leaflet.Id Leaflet.Msg
     | GeolocationMsg Geolocation.Msg

--- a/src/OS/Map/Subscriptions.elm
+++ b/src/OS/Map/Subscriptions.elm
@@ -1,5 +1,6 @@
 module OS.Map.Subscriptions exposing (subscriptions)
 
+import Utils.Ports.Leaflet as Leaflet
 import OS.Map.Config exposing (..)
 import OS.Map.Messages exposing (..)
 import OS.Map.Models exposing (..)
@@ -7,4 +8,4 @@ import OS.Map.Models exposing (..)
 
 subscriptions : Config msg -> Model -> Sub msg
 subscriptions config model =
-    Sub.none
+    Sub.map config.toMsg <| Leaflet.subscribe LeafletMsg

--- a/src/OS/Map/Update.elm
+++ b/src/OS/Map/Update.elm
@@ -12,6 +12,4 @@ type alias UpdateResponse msg =
 
 update : Config msg -> Msg -> Model -> UpdateResponse msg
 update config msg model =
-    case msg of
-        _ ->
-            ( model, React.none )
+    ( model, React.none )

--- a/src/Utils/Ports/Leaflet/Shape.elm
+++ b/src/Utils/Ports/Leaflet/Shape.elm
@@ -1,0 +1,372 @@
+module Utils.Ports.Leaflet.Shape
+    exposing
+        ( Shape
+        , Color
+        , Size
+        , Opacity
+        , Lines
+        , Latitude
+        , Longitude
+        , Coordinates
+        , polyline
+        , circle
+        , stroke
+        , color
+        , weight
+        , opacity
+        , fill
+        , fillColor
+        , fillOpacity
+        , lines
+        , radius
+        , position
+        , rgb
+        , coords
+        , encode
+        )
+
+import Json.Encode as Encode exposing (Value)
+
+
+{-| Opaque type for shapes, change it with the functions provided here then encode it.
+-}
+type Shape
+    = PolylineShape Path Polyline
+    | CircleShape Path Circle
+
+
+{-| Specific properties of Polyline.
+-}
+type alias Polyline =
+    { lines : Lines }
+
+
+{-| Specific properties of Circle.
+-}
+type alias Circle =
+    { position : Coordinates, radius : Size }
+
+
+{-| Generic properties, aplies both `Polyline` and `Circle`.
+-}
+type alias Path =
+    { stroke : Maybe Bool
+    , color : Color
+    , weight : Maybe Size
+    , opacity : Maybe Opacity
+    , fill : Maybe Bool
+    , fillColor : Maybe Color
+    , fillOpacity : Maybe Opacity
+    }
+
+
+{-| Red, green and blue color values.
+-}
+type alias Color =
+    ( Int, Int, Int )
+
+
+{-| Float value for sizes.
+-}
+type alias Size =
+    Float
+
+
+{-| Float value for opacity.
+-}
+type alias Opacity =
+    Float
+
+
+{-| A `List` of `Coordinates`.
+-}
+type alias Lines =
+    List Coordinates
+
+
+{-| Latitude coordinate.
+-}
+type alias Latitude =
+    Float
+
+
+{-| Longitude coordinate.
+-}
+type alias Longitude =
+    Float
+
+
+{-| Latitude and Longitude coordinates.
+-}
+type alias Coordinates =
+    { lat : Latitude
+    , lng : Longitude
+    }
+
+
+{-| Creates a polyline `Shape`, requires position, size and color
+-}
+polyline : Lines -> Color -> Shape
+polyline lines color =
+    PolylineShape (defaultPath color) (defaultPolyline lines)
+
+
+{-| Creates a circle `Shape`, requires position, size and color
+-}
+circle : Coordinates -> Size -> Color -> Shape
+circle position size color =
+    CircleShape (defaultPath color) (defaultCircle position size)
+
+
+
+-- properties
+
+
+{-| Sets `stroke` property of the `Shape`.
+-}
+stroke : Maybe Bool -> Shape -> Shape
+stroke value shape =
+    mapPath shape <| \path -> { path | stroke = value }
+
+
+{-| Sets `color` property of the `Shape`.
+-}
+color : Color -> Shape -> Shape
+color value shape =
+    mapPath shape <| \path -> { path | color = value }
+
+
+{-| Sets `weight` property of the `Shape`.
+-}
+weight : Maybe Size -> Shape -> Shape
+weight value shape =
+    mapPath shape <| \path -> { path | weight = value }
+
+
+{-| Sets `opacity` property of the `Shape`.
+-}
+opacity : Maybe Opacity -> Shape -> Shape
+opacity value shape =
+    mapPath shape <| \path -> { path | opacity = value }
+
+
+{-| Sets `fill` property of the `Shape`.
+-}
+fill : Maybe Bool -> Shape -> Shape
+fill value shape =
+    mapPath shape <| \path -> { path | fill = value }
+
+
+{-| Sets `fillColor` property of the `Shape`.
+-}
+fillColor : Maybe Color -> Shape -> Shape
+fillColor value shape =
+    mapPath shape <| \path -> { path | fillColor = value }
+
+
+{-| Sets `fillOpacity` property of the `Shape`.
+-}
+fillOpacity : Maybe Opacity -> Shape -> Shape
+fillOpacity value shape =
+    mapPath shape <| \path -> { path | fillOpacity = value }
+
+
+{-| Sets `lines` property of the `Polyline`.
+-}
+lines : Lines -> Shape -> Shape
+lines value shape =
+    mapPolyline shape <| \polyline -> { polyline | lines = value }
+
+
+{-| Sets `radius` property of the `Circle`.
+-}
+radius : Size -> Shape -> Shape
+radius value shape =
+    mapCircle shape <| \circle -> { circle | radius = value }
+
+
+{-| Sets `radius` property of the `Circle`.
+-}
+position : Coordinates -> Shape -> Shape
+position value shape =
+    mapCircle shape <| \circle -> { circle | position = value }
+
+
+
+-- fields & misc
+
+
+{-| Creates a `Color` from red, green and blue values.
+-}
+rgb : Int -> Int -> Int -> Color
+rgb =
+    (,,)
+
+
+{-| Creates `Coordinates` from latitude and longitude values.
+-}
+coords : Float -> Float -> Coordinates
+coords =
+    Coordinates
+
+
+{-| Encodes a `Shape` into a `Value`.
+-}
+encode : Shape -> Value
+encode =
+    encodeShape >> Encode.object
+
+
+
+-- Internals
+
+
+{-| Create a minimally configured `Path`.
+-}
+defaultPath : Color -> Path
+defaultPath color =
+    { stroke = Nothing
+    , color = color
+    , weight = Nothing
+    , opacity = Nothing
+    , fill = Nothing
+    , fillColor = Nothing
+    , fillOpacity = Nothing
+    }
+
+
+{-| Create a minimally configured `Polyline`.
+-}
+defaultPolyline : Lines -> Polyline
+defaultPolyline lines =
+    { lines = lines }
+
+
+{-| Create a minimally configured `Circle`.
+-}
+defaultCircle : Coordinates -> Size -> Circle
+defaultCircle position size =
+    { position = position, radius = size }
+
+
+{-| Maps `Path` of `Shape`.
+-}
+mapPath : Shape -> (Path -> Path) -> Shape
+mapPath shape apply =
+    case shape of
+        PolylineShape path polyline ->
+            PolylineShape (apply path) polyline
+
+        CircleShape path circle ->
+            CircleShape (apply path) circle
+
+
+{-| Maps `Polyline` of `Shape`.
+-}
+mapPolyline : Shape -> (Polyline -> Polyline) -> Shape
+mapPolyline shape apply =
+    case shape of
+        PolylineShape path polyline ->
+            PolylineShape path (apply polyline)
+
+        CircleShape path circle ->
+            CircleShape path circle
+
+
+{-| Maps `Circle` of `Shape`.
+-}
+mapCircle : Shape -> (Circle -> Circle) -> Shape
+mapCircle shape apply =
+    case shape of
+        PolylineShape path polyline ->
+            PolylineShape path polyline
+
+        CircleShape path circle ->
+            CircleShape path (apply circle)
+
+
+{-| Encodes a `Shape` into a `List (String, Value)`, useful to use with
+`Encode.object`.
+-}
+encodeShape : Shape -> List ( String, Value )
+encodeShape shape =
+    case shape of
+        PolylineShape path polyline ->
+            (encodePath path) ++ (encodePolyline polyline)
+
+        CircleShape path circle ->
+            (encodePath path) ++ (encodeCircle circle)
+
+
+{-| Encodes a `Path` into a `List (String, Value)`, useful to use with
+`Encode.object`.
+-}
+encodePath : Path -> List ( String, Value )
+encodePath path =
+    List.filterMap identity <|
+        [ maybe "stroke" Encode.bool path.stroke
+        , Just ( "color", encodeColor path.color )
+        , maybe "weight" Encode.float path.weight
+        , maybe "opacity" Encode.float path.opacity
+        , maybe "fill" Encode.bool path.fill
+        , maybe "fillColor" encodeColor path.fillColor
+        , maybe "fillOpacity" Encode.float path.fillOpacity
+        ]
+
+
+{-| Encode a `Color` into a `Value`.
+-}
+encodeColor : Color -> Value
+encodeColor ( r, g, b ) =
+    Encode.string <|
+        "rgb("
+            ++ (toString r)
+            ++ ", "
+            ++ (toString g)
+            ++ ", "
+            ++ (toString b)
+            ++ ")"
+
+
+{-| Encode a `Polyline` into a `List (String, Value)`, useful for
+`Encode.object`.
+-}
+encodePolyline : Polyline -> List ( String, Value )
+encodePolyline polyline =
+    List.filterMap identity
+        [ Just
+            ( "lines"
+            , polyline.lines
+                |> List.map encodeCoordinates
+                |> Encode.list
+            )
+        , Just ( "type", Encode.string "polyline" )
+        ]
+
+
+{-| Encode `Coordinates` into `Value`.
+-}
+encodeCoordinates : Coordinates -> Value
+encodeCoordinates { lat, lng } =
+    [ lat, lng ]
+        |> List.map Encode.float
+        |> Encode.list
+
+
+{-| Encode a `Circle` into a `List (String, Value)`, useful for
+`Encode.object`.
+-}
+encodeCircle : Circle -> List ( String, Value )
+encodeCircle circle =
+    List.filterMap identity
+        [ Just ( "radius", Encode.float circle.radius )
+        , Just ( "type", Encode.string "circle" )
+        , Just ( "position", encodeCoordinates circle.position )
+        ]
+
+
+{-| Helper for encoding optional properties.
+-}
+maybe : String -> (a -> Value) -> Maybe a -> Maybe ( String, Value )
+maybe key encode value =
+    Maybe.map (encode >> ((,) key)) value

--- a/static/js/leaflet.js
+++ b/static/js/leaflet.js
@@ -1,7 +1,7 @@
 var app = index.app;
 
 var maps = {};
-var address = '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+var address = "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
 
 function send(data) {
   app.ports.leafletSub.send(data);
@@ -10,35 +10,37 @@ function send(data) {
 function withElement(id, cb) {
   if (document.getElementById(id)) return cb();
 
-  var listener = function () {
+  var listener = function() {
     if (!document.getElementById(id)) return;
-    document.removeEventListener('DOMNodeInserted', listener);
+    document.removeEventListener("DOMNodeInserted", listener);
     cb();
   };
 
-  document.addEventListener('DOMNodeInserted', listener);
+  document.addEventListener("DOMNodeInserted", listener);
 }
 
-function init (cmd) {
+// creates a new map (cmd)
+function init(cmd) {
   var id = cmd.id;
 
-  withElement(id, function () {
-    var map = L.map(id, {zoomSnap: 0.25}).setView([-21.1, -45.54568], 16);
-    var projections = {test: L.latLng(-23.9949, -46.2569)};
+  withElement(id, function() {
+    var map = L.map(id, { zoomSnap: 0.25 }).setView([-21.1, -45.54568], 16);
+    var projections = { test: L.latLng(-23.9949, -46.2569) };
+    var shapes = {};
     var previousCenter = map.latLngToLayerPoint(map.getCenter());
 
-    L.tileLayer(address, {maxZoom: 18}).addTo(map);
-    maps[id] = [map, projections];
+    L.tileLayer(address, { maxZoom: 18 }).addTo(map);
+    maps[id] = [map, projections, shapes];
     map.invalidateSize();
 
     // click event
     function onMapClick(e) {
       // send click event
       send({
-        'id': id,
-        'msg': 'clicked',
-        'lat': e.latlng.lat,
-        'lng': e.latlng.lng
+        id: id,
+        msg: "clicked",
+        lat: e.latlng.lat,
+        lng: e.latlng.lng
         // TODO: maybe sending pixel coordinates would also be interesting
       });
     }
@@ -49,13 +51,13 @@ function init (cmd) {
 
       // semd diff
       send({
-        'id': id,
-        'msg': 'moved',
-        'x': previousCenter.x - center.x,
-        'y': previousCenter.y - center.y
+        id: id,
+        msg: "moved",
+        x: previousCenter.x - center.x,
+        y: previousCenter.y - center.y
       });
 
-      previousCenter = center
+      previousCenter = center;
 
       // send changed projections
       Object.keys(projections).forEach(name => {
@@ -63,21 +65,22 @@ function init (cmd) {
         var offset = map.latLngToLayerPoint(projections[name]);
 
         send({
-          'id': id,
-          'msg': 'projected',
-          'name': name,
-          'x': (size.x / 2) - (center.x - offset.x),
-          'y': (size.y / 2) - (center.y - offset.y)
+          id: id,
+          msg: "projected",
+          name: name,
+          x: size.x / 2 - (center.x - offset.x),
+          y: size.y / 2 - (center.y - offset.y)
         });
       });
     }
 
-    map.on('click', onMapClick);
-    map.on('move', onMapMove);
-    map.on('zoomanim', onMapMove);
+    map.on("click", onMapClick);
+    map.on("move", onMapMove);
+    map.on("zoomanim", onMapMove);
   });
 }
 
+// inserts projection tracker (cmd)
 function insertProjection(cmd) {
   var id = cmd.id;
   var name = cmd.name;
@@ -87,6 +90,7 @@ function insertProjection(cmd) {
   projections[name] = L.latLng(cmd.lat, cmd.lng);
 }
 
+// removes projection tracker (cmd)
 function removeProjection(cmd) {
   var id = cmd.id;
   var name = cmd.name;
@@ -96,9 +100,100 @@ function removeProjection(cmd) {
   delete projections[name];
 }
 
+// creates an with shape style
+function shapeStyle(shape) {
+  var opts = {};
+
+  if (shape.color !== undefined) opts.color = shape.color;
+  if (shape.opacity !== undefined) opts.opacity = shape.opacity;
+  if (shape.fill !== undefined) opts.fill = shape.fill;
+  if (shape.fillColor !== undefined) opts.fillColor = shape.fillColor;
+  if (shape.fillOpacity !== undefined) opts.fillOpacity = shape.fillOpacity;
+  if (shape.stroke !== undefined) opts.stroke = shape.stroke;
+  if (shape.weight !== undefined) opts.weight = shape.weight;
+
+  return opts;
+}
+
+// creates a new shape
+function insertShape(cmd) {
+  var map = maps[cmd.id] && maps[cmd.id][0];
+  var shapes = maps[cmd.id] && maps[cmd.id][2];
+
+  if (!map) return;
+  if (!shapes) return;
+
+  var opts = shapeStyle(cmd.shape);
+
+  if (cmd.shape.type === "polyline") {
+    var shape = L.polyline(cmd.shape.lines, opts);
+    shapes[cmd.name] = { type: "polyline", shape: shape };
+    shape.addTo(map);
+  } else if (cmd.shape.type === "circle") {
+    opts.radius = cmd.shape.radius;
+
+    var shape = L.circle(cmd.shape.position, opts);
+    shapes[cmd.name] = { type: "circle", shape: shape };
+    shape.addTo(map);
+  }
+}
+
+// updates existing shape
+function updateShape(cmd) {
+  var shapes = maps[cmd.id] && maps[cmd.id][2];
+
+  if (!shapes) return;
+
+  if (shapes[cmd.name]) {
+    var shape = shapes[cmd.name].shape;
+    var opts = shapeStyle(cmd.shape);
+
+    if (cmd.shape.type === "polyline") {
+      if (cmd.shape.lines) shape.setLatLngs(cmd.shape.lines);
+      shape.setStyle(opts);
+    } else if (cmd.shape.type === "circle") {
+      if (cmd.shape.position) shape.setLatLng(cmd.shape.position);
+      if (cmd.shape.radius) shape.setRadius(cmd.shape.radius);
+      shape.setStyle(opts);
+    }
+  }
+}
+
+// upserts shape (cmd)
+function setShape(cmd) {
+  var shapes = maps[cmd.id] && maps[cmd.id][2];
+
+  if (!shapes) return;
+
+  if (!shapes[cmd.name]) {
+    if (shapes[cmd.name].type !== cmd.shape.type) {
+      removeShape(cmd);
+      insertShape(cmd);
+    } else {
+      updateShape(cmd);
+    }
+  } else {
+    insertShape(cmd);
+  }
+}
+
+// removes shape (cmd)
+function removeShape(cmd) {
+  var map = maps[cmd.id] && maps[cmd.id][0];
+  var shapes = maps[cmd.id] && maps[cmd.id][2];
+
+  if (!map) return;
+  if (!shapes) return;
+
+  if (shapes[cmd.name]) {
+    map.removeLayer(shapes[cmd.name].shape);
+    delete shapes[cmd.name];
+  }
+}
+
+// centralizes the map (cmd)
 function center(cmd) {
-  var id = cmd.id
-  var map = maps[id] && maps[id][0];
+  var map = maps[cmd.id] && maps[cmd.id][0];
   if (!map) return;
 
   map.invalidateSize();
@@ -107,27 +202,33 @@ function center(cmd) {
 
 app.ports.leafletCmd.subscribe(function leafletCmd(cmd) {
   switch (cmd.msg) {
-    case 'init':
+    case "init":
       init(cmd);
       break;
 
-    case 'insertProjection':
+    case "insertProjection":
       insertProjection(cmd);
       break;
 
-    case 'removeProjection':
+    case "removeProjection":
       removeProjection(cmd);
       break;
 
-    case 'center':
+    case "setShape":
+      setShape(cmd);
+      break;
+
+    case "removeShape":
+      removeShape(cmd);
+      break;
+
+    case "center":
       center(cmd);
       break;
 
     default:
       console.log(
-        'Leaflet communication error: command "'
-        + cmd.msg
-        + '" does not exist.'
+        'Leaflet communication error: command "' + cmd.msg + '" does not exist.'
       );
   }
 });


### PR DESCRIPTION
Yay, now we're able to draw on the map with `Leaflet.setShape` and `Leaflet.removeShape`, it currently uses a `Shape` format defined in `Utils.Ports.Leaflet.Shape`.

I'm extremely happy with the result, this PR was also very fun to create:

> It's very simple, but very powerful.
> Unfortunately that comes with a price in code size, it's very extense to explain here in a quick talk.

Please try to understand the implementation, I'm eager to reply any every question.